### PR TITLE
Add domain table to domains list page

### DIFF
--- a/app/components/domains-table.tsx
+++ b/app/components/domains-table.tsx
@@ -45,34 +45,35 @@ export default function DomainsTable(props: DomainsTableProps) {
   }
 
   function renderDomainStatus(action: RecordStatus) {
-    switch (action) {
-      case 'active':
-        return (
-          <Tooltip label="Domain is live">
-            <CheckCircleIcon color="green.500" boxSize="6" />
-          </Tooltip>
-        );
-      case 'error':
-        return (
-          <Tooltip label="Domain error">
-            <WarningIcon color="brand.500" boxSize="6" />
-          </Tooltip>
-        );
-      case 'pending':
-        return (
-          <Tooltip label="Domain is pending">
-            <Flex
-              width="6"
-              height="6"
-              borderRadius="20"
-              alignItems="center"
-              justifyContent="center"
-              background="yellow.500"
-            >
-              <TimeIcon color="white" boxSize="3" />
-            </Flex>
-          </Tooltip>
-        );
+    if (action === 'active') {
+      return (
+        <Tooltip label="Domain is live">
+          <CheckCircleIcon color="green.500" boxSize="6" />
+        </Tooltip>
+      );
+    }
+    if (action === 'error') {
+      return (
+        <Tooltip label="Domain error">
+          <WarningIcon color="brand.500" boxSize="6" />
+        </Tooltip>
+      );
+    }
+    if (action === 'pending') {
+      return (
+        <Tooltip label="Domain is pending">
+          <Flex
+            width="6"
+            height="6"
+            borderRadius="20"
+            alignItems="center"
+            justifyContent="center"
+            background="yellow.500"
+          >
+            <TimeIcon color="white" boxSize="3" />
+          </Flex>
+        </Tooltip>
+      );
     }
   }
 
@@ -91,54 +92,52 @@ export default function DomainsTable(props: DomainsTableProps) {
             </Tr>
           </Thead>
           <Tbody>
-            {domains.map((domain) => {
-              return (
-                <Tr key={domain.id}>
-                  <Td>{renderDomainStatus(domain.status)}</Td>
-                  <Td>
-                    <Flex justifyContent="space-between" alignItems="center">
-                      {domain.name}
-                      <Tooltip label="Copy name to clipboard">
-                        <IconButton
-                          icon={<CopyIcon color="black" boxSize="5" />}
-                          aria-label="Refresh domain"
-                          variant="ghost"
-                          ml="2"
-                          onClick={() => onCopyNameToClipboard(domain.name)}
-                        />
-                      </Tooltip>
-                    </Flex>
-                  </Td>
-                  <Td>{domain.type}</Td>
-                  <Td>{domain.value}</Td>
-                  <Td>
-                    <Flex justifyContent="space-between" alignItems="center">
-                      {domain.expiresAt.toLocaleDateString('en-US')}
+            {domains.map((domain) => (
+              <Tr key={domain.id}>
+                <Td>{renderDomainStatus(domain.status)}</Td>
+                <Td>
+                  <Flex justifyContent="space-between" alignItems="center">
+                    {domain.name}
+                    <Tooltip label="Copy name to clipboard">
                       <IconButton
-                        icon={<RepeatIcon color="black" boxSize="5" />}
+                        icon={<CopyIcon color="black" boxSize="5" />}
                         aria-label="Refresh domain"
                         variant="ghost"
+                        ml="2"
+                        onClick={() => onCopyNameToClipboard(domain.name)}
                       />
-                    </Flex>
-                  </Td>
-                  <Td>
+                    </Tooltip>
+                  </Flex>
+                </Td>
+                <Td>{domain.type}</Td>
+                <Td>{domain.value}</Td>
+                <Td>
+                  <Flex justifyContent="space-between" alignItems="center">
+                    {domain.expiresAt.toLocaleDateString('en-US')}
                     <IconButton
-                      onClick={() => onAction(domain.id, 'EDIT')}
-                      icon={<EditIcon color="black" boxSize={5} />}
-                      aria-label="Edit domain"
-                      variant="ghost"
-                      mr="1"
-                    />
-                    <IconButton
-                      onClick={() => onAction(domain.id, 'DELETE')}
-                      icon={<DeleteIcon color="black" boxSize={5} />}
-                      aria-label="Delete domain"
+                      icon={<RepeatIcon color="black" boxSize="5" />}
+                      aria-label="Refresh domain"
                       variant="ghost"
                     />
-                  </Td>
-                </Tr>
-              );
-            })}
+                  </Flex>
+                </Td>
+                <Td>
+                  <IconButton
+                    onClick={() => onAction(domain.id, 'EDIT')}
+                    icon={<EditIcon color="black" boxSize={5} />}
+                    aria-label="Edit domain"
+                    variant="ghost"
+                    mr="1"
+                  />
+                  <IconButton
+                    onClick={() => onAction(domain.id, 'DELETE')}
+                    icon={<DeleteIcon color="black" boxSize={5} />}
+                    aria-label="Delete domain"
+                    variant="ghost"
+                  />
+                </Td>
+              </Tr>
+            ))}
           </Tbody>
         </Table>
       </TableContainer>

--- a/app/components/domains-table.tsx
+++ b/app/components/domains-table.tsx
@@ -1,0 +1,147 @@
+import {
+  Table,
+  Tr,
+  Th,
+  Thead,
+  Tbody,
+  TableContainer,
+  Td,
+  IconButton,
+  Flex,
+  Tooltip,
+  Card,
+  useToast,
+} from '@chakra-ui/react';
+import type { Record, RecordStatus } from '@prisma/client';
+import {
+  EditIcon,
+  DeleteIcon,
+  CheckCircleIcon,
+  RepeatIcon,
+  CopyIcon,
+  TimeIcon,
+  WarningIcon,
+} from '@chakra-ui/icons';
+
+interface DomainsTableProps {
+  domains: Record[];
+  onAction: (domaindID: number, action: DomainsTableAction) => void;
+}
+
+export type DomainsTableAction = 'EDIT' | 'DELETE' | 'RENEW';
+
+export default function DomainsTable(props: DomainsTableProps) {
+  const { domains, onAction } = props;
+
+  const toast = useToast();
+
+  function onCopyNameToClipboard(name: string) {
+    navigator.clipboard.writeText(name);
+    toast({
+      title: 'Name was copied to clipboard',
+      position: 'bottom-right',
+      status: 'success',
+    });
+  }
+
+  function renderDomainStatus(action: RecordStatus) {
+    switch (action) {
+      case 'active':
+        return (
+          <Tooltip label="Domain is live">
+            <CheckCircleIcon color="green.500" boxSize="6" />
+          </Tooltip>
+        );
+      case 'error':
+        return (
+          <Tooltip label="Domain error">
+            <WarningIcon color="brand.500" boxSize="6" />
+          </Tooltip>
+        );
+      case 'pending':
+        return (
+          <Tooltip label="Domain is pending">
+            <Flex
+              width="6"
+              height="6"
+              borderRadius="20"
+              alignItems="center"
+              justifyContent="center"
+              background="yellow.500"
+            >
+              <TimeIcon color="white" boxSize="3" />
+            </Flex>
+          </Tooltip>
+        );
+    }
+  }
+
+  return (
+    <Card p="2" mt="4">
+      <TableContainer>
+        <Table variant="striped" colorScheme="gray">
+          <Thead>
+            <Tr>
+              <Th />
+              <Th>Name</Th>
+              <Th>Type</Th>
+              <Th>Value</Th>
+              <Th>Expiration date</Th>
+              <Th />
+            </Tr>
+          </Thead>
+          <Tbody>
+            {domains.map((domain) => {
+              return (
+                <Tr key={domain.id}>
+                  <Td>{renderDomainStatus(domain.status)}</Td>
+                  <Td>
+                    <Flex justifyContent="space-between" alignItems="center">
+                      {domain.name}
+                      <Tooltip label="Copy name to clipboard">
+                        <IconButton
+                          icon={<CopyIcon color="black" boxSize="5" />}
+                          aria-label="Refresh domain"
+                          variant="ghost"
+                          ml="2"
+                          onClick={() => onCopyNameToClipboard(domain.name)}
+                        />
+                      </Tooltip>
+                    </Flex>
+                  </Td>
+                  <Td>{domain.type}</Td>
+                  <Td>{domain.value}</Td>
+                  <Td>
+                    <Flex justifyContent="space-between" alignItems="center">
+                      {domain.expiresAt.toLocaleDateString('en-US')}
+                      <IconButton
+                        icon={<RepeatIcon color="black" boxSize="5" />}
+                        aria-label="Refresh domain"
+                        variant="ghost"
+                      />
+                    </Flex>
+                  </Td>
+                  <Td>
+                    <IconButton
+                      onClick={() => onAction(domain.id, 'EDIT')}
+                      icon={<EditIcon color="black" boxSize={5} />}
+                      aria-label="Edit domain"
+                      variant="ghost"
+                      mr="1"
+                    />
+                    <IconButton
+                      onClick={() => onAction(domain.id, 'DELETE')}
+                      icon={<DeleteIcon color="black" boxSize={5} />}
+                      aria-label="Delete domain"
+                      variant="ghost"
+                    />
+                  </Td>
+                </Tr>
+              );
+            })}
+          </Tbody>
+        </Table>
+      </TableContainer>
+    </Card>
+  );
+}

--- a/app/mocks/domains.ts
+++ b/app/mocks/domains.ts
@@ -43,6 +43,20 @@ const DOMAINS_MOCK: Record[] = [
     course: null,
     ports: null,
   },
+  {
+    id: 2342343,
+    username: 'some-username',
+    name: 'some record name',
+    type: 'TXT',
+    value: 'This is an awesome domain! Definitely not spammy.',
+    description: 'lorem ipsum',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: new Date(),
+    status: 'active',
+    course: null,
+    ports: null,
+  },
 ];
 
 export default DOMAINS_MOCK;

--- a/app/mocks/domains.ts
+++ b/app/mocks/domains.ts
@@ -1,0 +1,48 @@
+import type { Record } from '@prisma/client';
+
+const DOMAINS_MOCK: Record[] = [
+  {
+    id: 123,
+    username: 'some-username',
+    name: 'name1',
+    type: 'CNAME',
+    value: 'github.com',
+    description: 'lorem ipsum',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: new Date(),
+    status: 'active',
+    course: null,
+    ports: null,
+  },
+  {
+    id: 321,
+    username: 'some-username',
+    name: 'name2',
+    type: 'AAAA',
+    value: '2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF',
+    description: 'lorem ipsum',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: new Date(),
+    status: 'error',
+    course: null,
+    ports: null,
+  },
+  {
+    id: 12312,
+    username: 'some-username',
+    name: 'name2',
+    type: 'A',
+    value: '2001:db8:3333:4444:CCCC:DDDD:EEEE:FFFF',
+    description: 'lorem ipsum',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    expiresAt: new Date(),
+    status: 'pending',
+    course: null,
+    ports: null,
+  },
+];
+
+export default DOMAINS_MOCK;

--- a/app/routes/__index/domains/index.tsx
+++ b/app/routes/__index/domains/index.tsx
@@ -1,11 +1,32 @@
-import { Heading } from '@chakra-ui/react';
+import { Container, Heading } from '@chakra-ui/react';
+import { useNavigate } from '@remix-run/react';
+import type { DomainsTableAction } from '~/components/domains-table';
+import DomainsTable from '~/components/domains-table';
+import DOMAINS_MOCK from '~/mocks/domains';
 
 export default function DomainsIndexRoute() {
+  const navigate = useNavigate();
+
+  function onDomainAction(domainID: number, action: DomainsTableAction) {
+    switch (action) {
+      case 'EDIT':
+        navigate(domainID.toString());
+        break;
+      case 'DELETE':
+        // TODO: implement delete functionaty
+        break;
+      case 'RENEW':
+        // TODO: implement renew functionaty
+        break;
+    }
+  }
+
   return (
-    <div>
-      <Heading as="h1" size="3xl">
+    <Container maxW="contianer.xl">
+      <Heading as="h1" size="2xl" mt="8">
         Domains List
       </Heading>
-    </div>
+      <DomainsTable domains={DOMAINS_MOCK} onAction={onDomainAction} />
+    </Container>
   );
 }

--- a/app/routes/__index/domains/index.tsx
+++ b/app/routes/__index/domains/index.tsx
@@ -24,7 +24,7 @@ export default function DomainsIndexRoute() {
   return (
     <Container maxW="contianer.xl">
       <Heading as="h1" size="xl" mt="8">
-        Domains List
+        Domains
       </Heading>
       <Text maxW="container.sm" mb="4" mt="2">
         Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has

--- a/app/routes/__index/domains/index.tsx
+++ b/app/routes/__index/domains/index.tsx
@@ -1,4 +1,4 @@
-import { Container, Heading } from '@chakra-ui/react';
+import { Container, Heading, Text } from '@chakra-ui/react';
 import { useNavigate } from '@remix-run/react';
 import type { DomainsTableAction } from '~/components/domains-table';
 import DomainsTable from '~/components/domains-table';
@@ -23,9 +23,14 @@ export default function DomainsIndexRoute() {
 
   return (
     <Container maxW="contianer.xl">
-      <Heading as="h1" size="2xl" mt="8">
+      <Heading as="h1" size="xl" mt="8">
         Domains List
       </Heading>
+      <Text maxW="container.sm" mb="4" mt="2">
+        Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+        been the industry's standard dummy text ever since the 1500s, when an unknown printer took a
+        galley of type and scrambled it to make a type specimen book.
+      </Text>
       <DomainsTable domains={DOMAINS_MOCK} onAction={onDomainAction} />
     </Container>
   );


### PR DESCRIPTION
### Overview
Added `DomainsTable` component, that takes `domains` and `onAction` props and renders Chakra UI table with domains. It also triggers `onAction` callback with different actions. Only `EDIT` action handling is implemented for now, since I need more back-end stuff updates to implement other actions handling. I also added mock file with some domains, just to have something to render for now.

Resolves #137

<img width="1054" alt="image" src="https://user-images.githubusercontent.com/32075241/218289003-7bff4f86-8458-44b7-93cf-a8a6a70e2be4.png">
