### PR TITLE
Add unit tests for Nodemailer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -79,6 +79,11 @@ jobs:
         image: motoserver/moto:4.1.1
         ports:
           - '5053:5000'
+      mailhog:
+        image: jcalonso/mailhog:latest
+        ports:
+          - 8025:8025
+          - 1025:1025
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "setup": "run-s db:generate db:push db:seed",
     "start": "cross-env NODE_ENV=production node ./build/server.js",
     "start:e2e": "cross-env NODE_ENV=production node --require dotenv/config ./build/server.js",
-    "test": "vitest",
+    "test": "cross-env NODE_OPTIONS=--require=dotenv/config vitest",
     "test:e2e:dev": "cross-env PORT=8080 start-server-and-test dev http://localhost:8080 \"playwright test\"",
     "pretest:e2e:run": "npm run build",
     "test:e2e:run": "cross-env PORT=8811 start-server-and-test start:e2e http://localhost:8811 \"playwright test\"",

--- a/test/unit/notifications.server.test.ts
+++ b/test/unit/notifications.server.test.ts
@@ -1,0 +1,40 @@
+import sendNotification from '../../app/lib/notifications.server';
+
+const { NOTIFICATIONS_EMAIL_USER } = process.env;
+
+describe('Notification server lib function test', () => {
+  const recipient = 'dev@starchart.invalid';
+  const subject = 'Sample subject';
+  const text = 'Sample text';
+
+  test('sending and receiving email notification using sendNotification()', async () => {
+    const sentMailResponse = await sendNotification(recipient, subject, text);
+
+    let messageId = sentMailResponse?.messageId;
+
+    expect(sentMailResponse).toEqual(
+      expect.objectContaining({
+        accepted: expect.arrayContaining([recipient]),
+      })
+    );
+
+    const mailhogResponse = await fetch(
+      `http://localhost:8025/api/v2/search?kind=to&query=${recipient}`
+    );
+    const responseToJSON = await mailhogResponse.json();
+    expect(responseToJSON.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          Content: expect.objectContaining({
+            Headers: expect.objectContaining({
+              'Message-ID': expect.arrayContaining([messageId]),
+              'To': expect.arrayContaining([recipient]),
+              'From': expect.arrayContaining([NOTIFICATIONS_EMAIL_USER]),
+            }),
+            Body: expect.stringMatching(text),
+          }),
+        }),
+      ])
+    );
+  });
+});


### PR DESCRIPTION
## Description
Resolves #147  by adding initial Unit Tests to test the functionality of Nodemailer. I had to adjust the `sendNotification` function for unit testing. Also, I  have modified the `tests` script to  require `dotenv/config` to read environment variables defined in `.env.example`.

### Steps to Test

1. Setup the project locally (make sure Docker is running)
2. Run `npm test` (all tests should pass)
3. Navigate to the MailHog interface at http://localhost:8025/ to see the test notification:
<img width="1447" alt="list view" src="https://user-images.githubusercontent.com/50856799/218293470-12d53f46-e397-4100-9a47-9d5cfd12a1a3.png">
<img width="1447" alt="detailed view" src="https://user-images.githubusercontent.com/50856799/218293466-88ee375f-390f-44a1-a5e6-893d7e118cec.png">
