### PR TITLE
chore: add docker and github actions to Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,14 +4,28 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
-      day: 'saturday'
+      day: 'tuesday'
       timezone: 'America/Toronto'
-
     labels:
-      - 'dependencies'
+      - 'npm dependencies'
 
-    reviewers:
-      - 'Seneca-CDOT/osd700-dps911-winter-2023'
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'tuesday'
+      timezone: 'America/Toronto'
+    labels:
+      - 'docker dependencies'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'tuesday'
+      timezone: 'America/Toronto'
+    labels:
+      - 'github-actions dependencies'
 
     open-pull-requests-limit: 5
     # disable auto rebasing


### PR DESCRIPTION
## Description
Resolves #135 by applying the following changes to the Dependabot configuration:
- Change scan day from Saturday to Tuesday
- Add configuration for Docker 
- Add configuration for GitHub Actions

### Additional Changes:
- Disable auto-assigning reviewers. This was done in the past but somehow got added again
- Update labels 