### PR TITLE
Add Docker build and push to CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -218,7 +218,7 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-  ESlint:
+  ESLint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -291,3 +291,44 @@ jobs:
             ./node_modules
             # cache node modules using the same key as restore.
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
+
+  Docker-Build:
+    # We'll only build and push when landing on main, not for PRs
+    if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+    runs-on: ubuntu-latest
+    # Don't bother unless everything else passes
+    needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract Docker metadata from git info
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/DevelopingSpace/starchart
+          flavor: latest=true
+          tags: |
+            type=ref,event=push
+            type=sha
+
+      - name: Log in to the GitHub Container Registry
+        uses: docker/login-action@2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@4
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Fixes #200

This adds a new dependent job to CI, which will build a new Docker image and push it to the GitHub Container Registry.  The job will only run if we're doing a `push` to `main` (i.e., not for PRs).  It will also not run unless the rest of the CI jobs work.