### PR TITLE
Add CRUD functions for models via Prisma

### DIFF
--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -1,0 +1,64 @@
+import type { Certificate } from '@prisma/client';
+
+import { prisma } from '~/db.server';
+
+export type { Certificate } from '@prisma/client';
+
+export async function getCertificateByUsername(username: Certificate['username']) {
+  return prisma.certificate.findUnique({ where: { username } });
+}
+
+export async function createCertificate(
+  username: Certificate['username'],
+  subject: Certificate['subject'],
+  certificate: Certificate['certificate'],
+  orderUrl: Certificate['orderUrl'],
+  privateKey: Certificate['privateKey']
+) {
+  // Set expiration date 90 days from now
+  const validTo = new Date();
+  validTo.setDate(validTo.getDate() + 90);
+
+  return prisma.certificate.create({
+    data: {
+      username,
+      subject,
+      certificate,
+      orderUrl,
+      privateKey,
+      validTo,
+    },
+  });
+}
+
+export async function updateCertificateByUsername(
+  username: Certificate['username'],
+  subject?: Certificate['subject'],
+  certificate?: Certificate['certificate'],
+  orderUrl?: Certificate['orderUrl'],
+  privateKey?: Certificate['privateKey'],
+  validFrom?: Certificate['validFrom']
+) {
+  // If validFrom is changed, set validTo to 90 days from validFrom
+  let validTo;
+  if (validFrom) {
+    validTo = validFrom;
+    validTo.setDate(validTo.getDate() + 90);
+  }
+  return prisma.certificate.update({
+    where: { username },
+    data: {
+      username,
+      subject,
+      certificate,
+      orderUrl,
+      privateKey,
+      validFrom,
+      validTo,
+    },
+  });
+}
+
+export async function deleteCertificateByUsername(username: Certificate['username']) {
+  return prisma.certificate.delete({ where: { username } });
+}

--- a/app/models/challenge.server.ts
+++ b/app/models/challenge.server.ts
@@ -1,0 +1,43 @@
+import type { Challenge } from '@prisma/client';
+
+import { prisma } from '~/db.server';
+
+export type { Challenge } from '@prisma/client';
+
+export async function getChallengeByCertificateId(certificateId: Challenge['certificateId']) {
+  return prisma.challenge.findMany({ where: { certificateId } });
+}
+
+export async function createChallenge(
+  domain: Challenge['domain'],
+  challengeKey: Challenge['challengeKey'],
+  certificateId: Challenge['certificateId']
+) {
+  return prisma.challenge.create({
+    data: {
+      domain,
+      challengeKey,
+      certificateId,
+    },
+  });
+}
+
+export async function updateChallengeById(
+  id: Challenge['id'],
+  certificateId?: Challenge['certificateId'],
+  domain?: Challenge['domain'],
+  challengeKey?: Challenge['challengeKey']
+) {
+  return prisma.challenge.update({
+    where: { id },
+    data: {
+      domain,
+      challengeKey,
+      certificateId,
+    },
+  });
+}
+
+export async function deleteChallengeById(id: Challenge['id']) {
+  return prisma.challenge.delete({ where: { id } });
+}

--- a/app/models/record.server.ts
+++ b/app/models/record.server.ts
@@ -1,0 +1,70 @@
+import type { Record } from '@prisma/client';
+
+import { prisma } from '~/db.server';
+
+export type { Record } from '@prisma/client';
+
+export async function getRecordsByUsername(username: Record['username']) {
+  return prisma.record.findMany({ where: { username } });
+}
+
+export async function createRecord(
+  username: Record['username'],
+  name: Record['name'],
+  type: Record['type'],
+  value: Record['value'],
+  status: Record['status'],
+  description?: Record['description'],
+  course?: Record['course'],
+  ports?: Record['ports']
+) {
+  // Set expiration date 6 months from now
+  const expiresAt = new Date();
+  expiresAt.setMonth(expiresAt.getMonth() + 6);
+
+  return prisma.record.create({
+    data: {
+      username,
+      name,
+      type,
+      value,
+      description,
+      course,
+      ports,
+      expiresAt,
+      status,
+    },
+  });
+}
+
+export async function updateRecordById(
+  id: Record['id'],
+  username?: Record['username'],
+  name?: Record['name'],
+  type?: Record['type'],
+  value?: Record['value'],
+  description?: Record['description'],
+  course?: Record['course'],
+  ports?: Record['ports'],
+  expiresAt?: Record['expiresAt'],
+  status?: Record['status']
+) {
+  return prisma.record.update({
+    where: { id },
+    data: {
+      username,
+      name,
+      type,
+      value,
+      description,
+      course,
+      ports,
+      expiresAt,
+      status,
+    },
+  });
+}
+
+export async function deleteRecordById(id: Record['id']) {
+  return prisma.record.delete({ where: { id } });
+}

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -24,6 +24,23 @@ export async function createUser(
   });
 }
 
-export async function deleteUserByEmail(email: User['email']) {
-  return prisma.user.delete({ where: { email } });
+export async function updateUserByUsername(
+  username: User['username'],
+  firstName?: User['firstName'],
+  lastName?: User['lastName'],
+  email?: User['email']
+) {
+  return prisma.user.update({
+    where: { username },
+    data: {
+      username,
+      firstName,
+      lastName,
+      email,
+    },
+  });
+}
+
+export async function deleteUserByUsername(username: User['username']) {
+  return prisma.user.delete({ where: { username } });
 }


### PR DESCRIPTION
Relates to #97

## Changes:
- This PR adds CRUD functions for models via Prisma, for model: User, Record, Certificate, Challenge.
- `deleteUserByEmail()` changes to `deleteUserByUsername()`

## Test:
1. You can try to use the functions to see if they function correctly as CRUD operations. 
- Option 1: You can use them in your code.
- Option 2: You can [make a query file](https://github.com/DevelopingSpace/starchart/wiki/Prisma#3-write-your-first-query) to import and execute these functions.
NOTE: `npx ts-node` needs to have `--require tsconfig-paths/register` or it won't understand `~` for paths( to `db.bserver` and `logger.server`) in our project.

2. `npm run db:studio` can let you view data in database after an operation.

