### PR TITLE
Fix version string for Docker GitHub Actions in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -335,14 +335,14 @@ jobs:
             type=sha
 
       - name: Log in to the GitHub Container Registry
-        uses: docker/login-action@2
+        uses: docker/login-action@v2
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@4
+        uses: docker/build-push-action@v4
         with:
           context: .
           push: true


### PR DESCRIPTION
Typo in the version numbers I'm using for the Docker GitHub Actions: missing `v`