### PR TITLE
Use proper event name (branch vs. push) in docker metadata

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -331,7 +331,7 @@ jobs:
           images: ghcr.io/DevelopingSpace/starchart
           flavor: latest=true
           tags: |
-            type=ref,event=push
+            type=ref,event=branch
             type=sha
 
       - name: Log in to the GitHub Container Registry


### PR DESCRIPTION
I have a mistake in the `event` type I used.  According to https://github.com/docker/metadata-action#typeref it should be `branch` vs. `push`, despite the table below it indicating that `push` is allowed.