### PR TITLE
Improve domain name validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "react-dom": "^18.2.0",
         "samlify": "^2.8.8",
         "tiny-invariant": "^1.3.1",
+        "validator": "^13.9.0",
         "winston": "^3.8.2"
       },
       "devDependencies": {
@@ -56,6 +57,7 @@
         "@types/nodemailer": "^6.4.7",
         "@types/react": "^18.0.28",
         "@types/react-dom": "^18.0.11",
+        "@types/validator": "^13.7.12",
         "@vitejs/plugin-react": "^3.0.1",
         "@vitest/coverage-c8": "^0.28.5",
         "autoprefixer": "^10.4.13",
@@ -6928,6 +6930,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.12",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.12.tgz",
+      "integrity": "sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -20535,6 +20543,14 @@
         "spdx-expression-parse": "^3.0.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -26775,6 +26791,12 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==",
+      "dev": true
+    },
+    "@types/validator": {
+      "version": "13.7.12",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.12.tgz",
+      "integrity": "sha512-YVtyAPqpefU+Mm/qqnOANW6IkqKpCSrarcyV269C8MA8Ux0dbkEuQwM/4CjL47kVEM2LgBef/ETfkH+c6+moFA==",
       "dev": true
     },
     "@types/yargs": {
@@ -36710,6 +36732,11 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
+    },
+    "validator": {
+      "version": "13.9.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.9.0.tgz",
+      "integrity": "sha512-B+dGG8U3fdtM0/aNK4/X8CXq/EcxU2WPrPEkJGslb47qyHsxmbggTWK0yEA4qnYVNF+nxNlN88o14hIcPmSIEA=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
     "react-dom": "^18.2.0",
     "samlify": "^2.8.8",
     "tiny-invariant": "^1.3.1",
+    "validator": "^13.9.0",
     "winston": "^3.8.2"
   },
   "devDependencies": {
@@ -78,6 +79,7 @@
     "@types/nodemailer": "^6.4.7",
     "@types/react": "^18.0.28",
     "@types/react-dom": "^18.0.11",
+    "@types/validator": "^13.7.12",
     "@vitejs/plugin-react": "^3.0.1",
     "@vitest/coverage-c8": "^0.28.5",
     "autoprefixer": "^10.4.13",


### PR DESCRIPTION
Resolve #185 

Adding domain name validation as following rules

- Domain name pattern should be `[name].[studentId].rootDomain.com(.)`
- Domain name can contain only alphanumerical characters, `-`, and `_`
- Domain name should not start or end with `-`
- Domain name cannot contain multiple consecutive `-` or `_`
- Domain name can contain uppercase in UI but it is converted to lowercase before validation
- `studentId` only contains alphanumerical characters

Also domain name is lowercased before adding it to Route 53, but original name is stored in DB