### PR TITLE
Use shared redis connection in FlowProducer

### DIFF
--- a/app/queues/certificate/certificate-flow.server.ts
+++ b/app/queues/certificate/certificate-flow.server.ts
@@ -8,6 +8,8 @@ import {
 import { orderCompleterQueueName, orderCompleterWorker } from './order-completer-worker.server';
 import { dnsCleanerQueueName, dnsCleanerWorker } from './dns-cleaner-worker.server';
 
+import { redis } from '~/lib/redis.server';
+
 import type { FlowJob } from 'bullmq';
 import type { OrderCreatorData } from './order-creator-worker.server';
 import type { DnsWaiterData } from './dns-waiter-worker.server';
@@ -24,7 +26,7 @@ export {
   dnsCleanerWorker,
 };
 
-const flowProducer = new FlowProducer();
+const flowProducer = new FlowProducer({ connection: redis });
 
 export const addCertRequest = async (rootDomain: string) => {
   /**


### PR DESCRIPTION
While working on #43, I ran into a bug where the container can't connect to Redis.  It turns out to be that if you don't specify redis connection options, the `FlowProducer` will try to use `localhost`.

This updates our `FlowProducer` to use the shared `redis` connection we have. 