### PR TITLE
Domains listing integration from server + delete UI

### DIFF
--- a/app/components/domains-delete-alert-dialog.tsx
+++ b/app/components/domains-delete-alert-dialog.tsx
@@ -1,0 +1,42 @@
+import {
+  AlertDialog,
+  Button,
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogBody,
+} from '@chakra-ui/react';
+import React from 'react';
+
+interface DomainsDeleteAlertDialogProps {
+  isOpen: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}
+
+export default function DomainsDeleteAlertDialog(props: DomainsDeleteAlertDialogProps) {
+  const { isOpen, onCancel, onConfirm } = props;
+  const cancelRef = React.useRef(null);
+
+  return (
+    <AlertDialog isCentered isOpen={isOpen} onClose={onCancel} leastDestructiveRef={cancelRef}>
+      <AlertDialogOverlay>
+        <AlertDialogContent>
+          <AlertDialogHeader fontSize="lg" fontWeight="bold">
+            Delete Domain
+          </AlertDialogHeader>
+          <AlertDialogBody>Are you sure? You can't undo this action afterwards.</AlertDialogBody>
+          <AlertDialogFooter>
+            <Button colorScheme="gray" onClick={onCancel} ref={cancelRef}>
+              Cancel
+            </Button>
+            <Button colorScheme="brand" onClick={onConfirm} ml="3">
+              Delete
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialogOverlay>
+    </AlertDialog>
+  );
+}

--- a/app/routes/__index/domains/index.tsx
+++ b/app/routes/__index/domains/index.tsx
@@ -1,22 +1,38 @@
 import { AddIcon } from '@chakra-ui/icons';
 import { Button, Container, Flex, Heading, Text } from '@chakra-ui/react';
+import type { LoaderArgs } from '@remix-run/node';
+import { Response } from '@remix-run/node';
 import { Link, useNavigate } from '@remix-run/react';
 import type { DomainsTableAction } from '~/components/domains-table';
 import DomainsTable from '~/components/domains-table';
-import DOMAINS_MOCK from '~/mocks/domains';
+import { getRecordsByUsername } from '~/models/record.server';
+import { getUser } from '~/session.server';
+import type { Record } from '@prisma/client';
+import { typedjson, useTypedLoaderData } from 'remix-typedjson';
+
+export const loader = async ({ request }: LoaderArgs) => {
+  const user = await getUser(request);
+  if (!user) {
+    throw new Response('No user', { status: 500 });
+  }
+
+  return typedjson(await getRecordsByUsername(user.username));
+};
 
 export default function DomainsIndexRoute() {
+  const domains = useTypedLoaderData<typeof loader>();
   const navigate = useNavigate();
 
-  function onDomainAction(domainID: number, action: DomainsTableAction) {
+  function onDomainAction(domain: Record, action: DomainsTableAction) {
     switch (action) {
       case 'EDIT':
-        navigate(domainID.toString());
+        navigate(domain.id.toString());
         break;
       case 'DELETE':
-        // TODO: implement delete functionaty
+        console.log('Delete: ', domain);
         break;
       case 'RENEW':
+        console.log('Renew: ', domain);
         // TODO: implement renew functionaty
         break;
     }
@@ -37,7 +53,7 @@ export default function DomainsIndexRoute() {
           <Button rightIcon={<AddIcon boxSize={3} />}>Create new domain</Button>
         </Link>
       </Flex>
-      <DomainsTable domains={DOMAINS_MOCK} onAction={onDomainAction} />
+      <DomainsTable domains={domains} onAction={onDomainAction} />
     </Container>
   );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "nodemailer": "^6.9.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "remix-typedjson": "^0.1.7",
         "samlify": "^2.8.8",
         "tiny-invariant": "^1.3.1",
         "winston": "^3.8.2"
@@ -18361,6 +18362,16 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remix-typedjson": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/remix-typedjson/-/remix-typedjson-0.1.7.tgz",
+      "integrity": "sha512-h7WoKbKBGsVdZZp3s79U5SDrMvQ3We7BjGaSIPxchnJOTS3GUDat0kBoy/gh9TVKRf5KYCee+K1UlFAYQmLQsA==",
+      "peerDependencies": {
+        "@remix-run/react": "^1.6.5",
+        "@remix-run/server-runtime": "^1.6.5",
+        "react": "^17.0.2 || ^18.0.0"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -35033,6 +35044,11 @@
         "mdast-util-to-hast": "^11.0.0",
         "unified": "^10.0.0"
       }
+    },
+    "remix-typedjson": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/remix-typedjson/-/remix-typedjson-0.1.7.tgz",
+      "integrity": "sha512-h7WoKbKBGsVdZZp3s79U5SDrMvQ3We7BjGaSIPxchnJOTS3GUDat0kBoy/gh9TVKRf5KYCee+K1UlFAYQmLQsA=="
     },
     "require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "nodemailer": "^6.9.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "remix-typedjson": "^0.1.7",
     "samlify": "^2.8.8",
     "tiny-invariant": "^1.3.1",
     "winston": "^3.8.2"


### PR DESCRIPTION
## Overview
What this PR does: 
- it adds loading of the domain from the server side instead of showing mock domains
- it adds the UI for deleting domains (Alert Dialog) 

### Fetching domains
integrating fetching domains using standard `json` and `useLoaderData` I faced an issue:
**Remix serialize and deserializes data sent from the server, but it doesn't deserialize dates, so return them like strings.**

This is a known problem in Remix and I found the discussion about it: https://github.com/remix-run/remix/discussions/1910

I found the solution of using `remix-typedjson` the most simple and beautiful. Using that lib you need just:
- `json` -> `typedjson`
- `useLoaderData` -> `useTypedLoaderData`

Using that now we can freely reuse types from Prisma without writing any custom converters, serializers etc. 

 ### Alert dialog
 I also added a simple Alert dialogue which let user know that changes of deleting the domain are irreversible. Took the component from Chakra 
 https://chakra-ui.com/docs/components/alert-dialog
 
 ### Some screenshots 
![image](https://user-images.githubusercontent.com/32075241/219896267-539b72d6-c8c8-4f08-800c-b4731d20e8c2.png)
![image](https://user-images.githubusercontent.com/32075241/219896339-461305e3-3cbf-4f1d-94a4-986cce094f32.png)

closes #197 
