### PR TITLE
feat: Queue worker for order creation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,12 @@ DATABASE_URL="mysql://starchart:starchart_password@127.0.0.1:3306/starchart"
 # Connect to Redis container locally
 REDIS_URL=redis://localhost:6379
 
+# Let's encrypt directory URL (the server we request the cert from)
+# Staging: 'https://acme-staging-v02.api.letsencrypt.org/directory'
+# Production 'https://acme-v02.api.letsencrypt.org/directory'
+# Local development / testing docker container 'https://127.0.0.1:14000/dir'
+LETS_ENCRYPT_DIRECTORY_URL="https://127.0.0.1:14000/dir"
+
 # https://letsencrypt.org/docs/expiration-emails/
 LETS_ENCRYPT_ACCOUNT_EMAIL="nx@senecacollege.ca"
 

--- a/app/components/certificate/certificate-request.tsx
+++ b/app/components/certificate/certificate-request.tsx
@@ -4,24 +4,15 @@ import Description from './description';
 
 interface CertificateRequestViewProps {
   domain: string;
-  validFrom: Date;
-  validTo: Date;
   onRequest: () => void;
 }
 
-export default function CertificateRequestView({
-  domain,
-  validFrom,
-  validTo,
-  onRequest,
-}: CertificateRequestViewProps) {
+export default function CertificateRequestView({ domain, onRequest }: CertificateRequestViewProps) {
   return (
     <Flex flexDirection="column" gap="5" width="4xl">
       <Description
         description="Initial: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s"
         certRequested={false}
-        validFrom={validFrom}
-        validTo={validTo}
       />
       <Flex flexDirection="column" gap="1">
         <Heading as="h3" size="md" marginBottom="3">

--- a/app/components/certificate/certificate-request.tsx
+++ b/app/components/certificate/certificate-request.tsx
@@ -3,14 +3,14 @@ import { Flex, Heading, Text, HStack, Button } from '@chakra-ui/react';
 import Description from './description';
 
 interface CertificateRequestViewProps {
-  subject: string;
+  domain: string;
   validFrom: Date;
   validTo: Date;
   onRequest: () => void;
 }
 
 export default function CertificateRequestView({
-  subject,
+  domain,
   validFrom,
   validTo,
   onRequest,
@@ -30,7 +30,7 @@ export default function CertificateRequestView({
         <Text>Lorem Ipsum is simply dummy text of the printing and typesetting industry</Text>
 
         <HStack>
-          <Text fontWeight="bold">Domain Name:</Text> <Text>{subject}</Text>
+          <Text fontWeight="bold">Domain Name:</Text> <Text>{domain}</Text>
         </HStack>
       </Flex>
       <Button width="3xs" shadow="xl" onClick={onRequest}>

--- a/app/components/certificate/description.tsx
+++ b/app/components/certificate/description.tsx
@@ -2,8 +2,8 @@ import { Flex, Heading, Text, HStack, VStack } from '@chakra-ui/react';
 
 interface DescriptionSectionProps {
   certRequested: boolean;
-  validFrom: Date;
-  validTo: Date;
+  validFrom?: Date;
+  validTo?: Date;
   description: string;
 }
 
@@ -21,14 +21,18 @@ export default function DescriptionSection({
       <Text>{description}</Text>
       {certRequested && (
         <HStack gap="6" marginTop="2">
-          <VStack>
-            <Text fontWeight="bold">Created On</Text>
-            <Text>{validFrom.toDateString()}</Text>
-          </VStack>
-          <VStack>
-            <Text fontWeight="bold">Expires On</Text>
-            <Text>{validTo.toDateString()}</Text>
-          </VStack>
+          {!!validFrom && !!validTo && (
+            <>
+              <VStack>
+                <Text fontWeight="bold">Created On</Text>
+                <Text>{validFrom.toDateString()}</Text>
+              </VStack>
+              <VStack>
+                <Text fontWeight="bold">Expires On</Text>
+                <Text>{validTo.toDateString()}</Text>
+              </VStack>
+            </>
+          )}
         </HStack>
       )}
     </Flex>

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -4,8 +4,15 @@ import { prisma } from '~/db.server';
 
 export type { Certificate } from '@prisma/client';
 
-export function getCertificateByUsername(username: Certificate['username']) {
-  return prisma.certificate.findUnique({ where: { username } });
+export function getIssuedCertificateByUsername(username: Certificate['username']) {
+  // Get the most recently created one
+  return prisma.certificate
+    .findMany({
+      where: { username, status: 'issued' },
+      orderBy: { validFrom: 'desc' },
+      take: 1,
+    })
+    .then(([certificate]) => certificate);
 }
 
 export function getCertificateById(id: Certificate['id']) {
@@ -15,7 +22,7 @@ export function getCertificateById(id: Certificate['id']) {
 export async function createCertificate(
   data: Pick<Certificate, 'username' | 'domain' | 'orderUrl'>
 ) {
-  return prisma.certificate.create({ data });
+  return prisma.certificate.create({ data: { ...data } });
 }
 
 export function updateCertificateById(

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -5,7 +5,10 @@ import { prisma } from '~/db.server';
 export type { Certificate } from '@prisma/client';
 
 export function getIssuedCertificateByUsername(username: Certificate['username']) {
-  // Get the most recently created one
+  /**
+   * There might be multiple certificates in the db for the same user, let's get
+   * the most recent one that has been successfully issued
+   */
   return prisma.certificate
     .findMany({
       where: { username, status: 'issued' },
@@ -19,9 +22,7 @@ export function getCertificateById(id: Certificate['id']) {
   return prisma.certificate.findUnique({ where: { id } });
 }
 
-export async function createCertificate(
-  data: Pick<Certificate, 'username' | 'domain' | 'orderUrl'>
-) {
+export function createCertificate(data: Pick<Certificate, 'username' | 'domain' | 'orderUrl'>) {
   return prisma.certificate.create({ data: { ...data } });
 }
 

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -4,61 +4,30 @@ import { prisma } from '~/db.server';
 
 export type { Certificate } from '@prisma/client';
 
-export async function getCertificateByUsername(username: Certificate['username']) {
+export function getCertificateByUsername(username: Certificate['username']) {
   return prisma.certificate.findUnique({ where: { username } });
 }
 
+export function getCertificateById(id: Certificate['id']) {
+  return prisma.certificate.findUnique({ where: { id } });
+}
+
 export async function createCertificate(
-  username: Certificate['username'],
-  subject: Certificate['subject'],
-  certificate: Certificate['certificate'],
-  orderUrl: Certificate['orderUrl'],
-  privateKey: Certificate['privateKey']
+  data: Pick<Certificate, 'username' | 'domain' | 'orderUrl'>
 ) {
-  // Set expiration date 90 days from now
-  const validTo = new Date();
-  validTo.setDate(validTo.getDate() + 90);
-
-  return prisma.certificate.create({
-    data: {
-      username,
-      subject,
-      certificate,
-      orderUrl,
-      privateKey,
-      validTo,
-    },
-  });
+  return prisma.certificate.create({ data });
 }
 
-export async function updateCertificateByUsername(
-  username: Certificate['username'],
-  subject?: Certificate['subject'],
-  certificate?: Certificate['certificate'],
-  orderUrl?: Certificate['orderUrl'],
-  privateKey?: Certificate['privateKey'],
-  validFrom?: Certificate['validFrom']
+export function updateCertificateById(
+  id: number,
+  data: Pick<Certificate, 'certificate' | 'privateKey' | 'validFrom' | 'validTo'>
 ) {
-  // If validFrom is changed, set validTo to 90 days from validFrom
-  let validTo;
-  if (validFrom) {
-    validTo = validFrom;
-    validTo.setDate(validTo.getDate() + 90);
-  }
   return prisma.certificate.update({
-    where: { username },
-    data: {
-      username,
-      subject,
-      certificate,
-      orderUrl,
-      privateKey,
-      validFrom,
-      validTo,
-    },
+    where: { id },
+    data,
   });
 }
 
-export async function deleteCertificateByUsername(username: Certificate['username']) {
-  return prisma.certificate.delete({ where: { username } });
+export function deleteCertificateById(id: Certificate['id']) {
+  return prisma.certificate.delete({ where: { id } });
 }

--- a/app/models/challenge.server.ts
+++ b/app/models/challenge.server.ts
@@ -4,40 +4,16 @@ import { prisma } from '~/db.server';
 
 export type { Challenge } from '@prisma/client';
 
-export async function getChallengeByCertificateId(certificateId: Challenge['certificateId']) {
+export function getChallengesByCertificateId(certificateId: Challenge['certificateId']) {
   return prisma.challenge.findMany({ where: { certificateId } });
 }
 
-export async function createChallenge(
-  domain: Challenge['domain'],
-  challengeKey: Challenge['challengeKey'],
-  certificateId: Challenge['certificateId']
+export function createChallenge(
+  data: Pick<Challenge, 'domain' | 'challengeKey' | 'certificateId'>
 ) {
-  return prisma.challenge.create({
-    data: {
-      domain,
-      challengeKey,
-      certificateId,
-    },
-  });
+  return prisma.challenge.create({ data });
 }
 
-export async function updateChallengeById(
-  id: Challenge['id'],
-  certificateId?: Challenge['certificateId'],
-  domain?: Challenge['domain'],
-  challengeKey?: Challenge['challengeKey']
-) {
-  return prisma.challenge.update({
-    where: { id },
-    data: {
-      domain,
-      challengeKey,
-      certificateId,
-    },
-  });
-}
-
-export async function deleteChallengeById(id: Challenge['id']) {
+export function deleteChallengeById(id: Challenge['id']) {
   return prisma.challenge.delete({ where: { id } });
 }

--- a/app/queues/certificate/challenge-completer-worker.server.ts
+++ b/app/queues/certificate/challenge-completer-worker.server.ts
@@ -4,6 +4,7 @@ import logger from '~/lib/logger.server';
 
 export interface ChallengeCompleterData {
   rootDomain: string;
+  username: string;
 }
 
 export const challengeCompleterQueueName = 'certificate-completeChallenges';
@@ -12,7 +13,7 @@ export const challengeCompleterWorker = new Worker<ChallengeCompleterData>(
   challengeCompleterQueueName,
   async (job) => {
     const { rootDomain } = job.data;
-    logger.info(`TODO create order for ${rootDomain}`);
+    logger.info(`TODO complete challenges for ${rootDomain}`);
   },
   { connection: redis }
 );

--- a/app/queues/certificate/dns-cleaner-worker.server.ts
+++ b/app/queues/certificate/dns-cleaner-worker.server.ts
@@ -4,6 +4,7 @@ import logger from '~/lib/logger.server';
 
 export interface DnsCleanerData {
   rootDomain: string;
+  username: string;
 }
 
 export const dnsCleanerQueueName = 'certificate-cleanDns';

--- a/app/queues/certificate/dns-waiter-worker.server.ts
+++ b/app/queues/certificate/dns-waiter-worker.server.ts
@@ -4,6 +4,7 @@ import logger from '~/lib/logger.server';
 
 export interface DnsWaiterData {
   rootDomain: string;
+  username: string;
 }
 
 export const dnsWaiterQueueName = 'certificate-waitDns';

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -4,6 +4,7 @@ import logger from '~/lib/logger.server';
 
 export interface OrderCompleterData {
   rootDomain: string;
+  username: string;
 }
 
 export const orderCompleterQueueName = 'certificate-completeOrder';

--- a/app/queues/certificate/order-creator-worker.server.ts
+++ b/app/queues/certificate/order-creator-worker.server.ts
@@ -1,18 +1,146 @@
-import { Worker } from 'bullmq';
+import { Worker, UnrecoverableError } from 'bullmq';
 import { redis } from '~/lib/redis.server';
 import logger from '~/lib/logger.server';
+import LetsEncrypt from '~/lib/lets-encrypt.server';
+import * as certificateModel from '~/models/certificate.server';
+import * as challengeModel from '~/models/challenge.server';
+
+import type { ChallengeBundle } from '~/lib/lets-encrypt.server';
 
 export interface OrderCreatorData {
   rootDomain: string;
+  username: string;
+}
+
+export interface OrderCreatorOutputData {
+  certificateId: number;
+  username: string;
+  rootDomain: string;
+  orderUrl: string;
+  challengeEntries: {
+    id: number;
+    domain: string;
+    challengeKey: string;
+  }[];
 }
 
 export const orderCreatorQueueName = 'certificate-createOrder';
 
-export const orderCreatorWorker = new Worker<OrderCreatorData>(
+/**
+ * This async fn handles adding challenges to DB and DNS
+ */
+const handleChallenges = (certificateId: number, bundles: ChallengeBundle[]) => {
+  const challengeInsertPromises = bundles.map(async ({ domain, value: challengeKey }) => {
+    logger.info(`Adding challenge to DNS`, { domain, challengeKey });
+
+    /**
+     * TODO actually add challenge to DNS
+     */
+
+    return challengeModel.createChallenge({
+      domain,
+      challengeKey,
+      certificateId,
+    });
+  });
+
+  return Promise.all(challengeInsertPromises);
+};
+
+/**
+ * This BullMQ job is the first in the chain when generating an SSL certificate
+ *
+ * It initializes Let's encrypt, creates an order, retrieves the challenges
+ * stores all this information in the DB and also passes it down to the
+ * next BullMQ worker in our flow
+ */
+
+export const orderCreatorWorker = new Worker<OrderCreatorData, OrderCreatorOutputData>(
   orderCreatorQueueName,
   async (job) => {
-    const { rootDomain } = job.data;
-    logger.info(`TODO create order for ${rootDomain}`);
+    const { rootDomain, username } = job.data;
+
+    logger.info(`Creating certificate order for ${rootDomain}`);
+
+    let letsEncrypt;
+    /**
+     * Initialize Let's Encrypt
+     */
+    try {
+      logger.debug("Initializing Let's encrypt");
+      letsEncrypt = await new LetsEncrypt().initialize();
+    } catch (e) {
+      // If initialize failed, we almost certainly have a setup error.
+      // Let's rethrow this as an UnrecoverableError, but preserve the message and stack
+
+      logger.error("Failed to initialize Let's encrypt, rethrowing error as Unrecoverable", e);
+
+      const newError = new UnrecoverableError((e as Error).message);
+      newError.stack = (e as Error).stack;
+      throw newError;
+    }
+
+    /**
+     * We have a working LE now, let's create an order
+     */
+    try {
+      logger.debug(`Creating ACME order for ${rootDomain}`);
+      await letsEncrypt.createOrder(rootDomain);
+    } catch (e) {
+      // Log and rethrow the same error to keep message and stack
+      logger.error("Failed to create a Let's Encrypt order", e);
+      throw e;
+    }
+    logger.info(`Order created successfully`);
+
+    /**
+     * Store order data in the DB
+     */
+    let certificateId;
+    try {
+      // Destructuring assignment to existing variable
+      ({ id: certificateId } = await certificateModel.createCertificate({
+        username,
+        domain: rootDomain,
+        orderUrl: letsEncrypt.order!.url,
+      }));
+      logger.info(`Order created successfully, added to db with id: ${certificateId}`);
+    } catch (e) {
+      // Log and rethrow the same error to keep message and stack
+      logger.error(`Failed to insert certificate into db`, e);
+      throw e;
+    }
+
+    /**
+     * Add challenges to DB and DNS, get back id, domain, challengeKey, for each of them
+     */
+
+    let challengeEntries;
+    try {
+      challengeEntries = (await handleChallenges(certificateId, letsEncrypt.challengeBundles!)).map(
+        ({ id, domain, challengeKey }) => ({
+          id,
+          domain,
+          challengeKey,
+        })
+      );
+      logger.info('All challenge entries have been added');
+    } catch (e) {
+      // Log and rethrow the same error to keep message and stack
+      logger.error(`Failed to add challenge entries`, e);
+      throw e;
+    }
+
+    /**
+     * We will return this data to BullMQ, so subsequent jobs can make use of this information
+     */
+    return {
+      certificateId,
+      username,
+      rootDomain,
+      orderUrl: letsEncrypt.order!.url,
+      challengeEntries,
+    } as OrderCreatorOutputData;
   },
   { connection: redis }
 );

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -16,7 +16,7 @@ export default function CertificateIndexRoute() {
   const certificate: Certificate = {
     id: 1,
     username: 'user_test',
-    subject: `*.user_test.example.com`,
+    domain: `user_test.example.com`,
     certificate:
       'Public----BEGIN CERTIFICATE-----MIIFMjCCAxoCCQCVordquLnq8TANBgkqhkiG9w0BAQUFADBbMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRQwEgYDVQQDEwtleGFtcGxlLmNvbTAeFw0xNzA5MTQxNDMzMTRaFw0xODA5MTQxNDMzMTRaMFsxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFDASBgNVBAMTC2V4YW1wbGUuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwi2PYBNGl1n78niRGDKgcsWK03TcTeVbQ1HztA57Rr1iDHAZNx3Mv4E/Sha8VKbKoshcmUcOS3AlmbIZX+7+9c7lL2oD+vtUZF1YUR/69fWuO72wk6fKj/eofxH9Ud5KFje8qrYZdJWKkPMdWlYgjD6qpA5wl60NiuxmUr44ADZDytqHzNThN3wrFruz74PcMfakcSUMxkh98LuNeGtqHpEAw+wliko3oDD4PanvDvp5mRgiQVKHEGT7dm85Up+W1iJKJ65fkc/j940MaLbdISZYYCT5dtPgCGKCHgVuVrY+OXFJrD3TTm94ILsR/BkS/VSKNigGVPXg3q8tgIS++k13CzLUO0PNRMuod1RD9j5NEc2CVic9rcH06ugZyHlOcuVvvRsPGd52BPn+Jf1aePKPPQHxT9i5GOs80CJw0eduZCDZB32biRYNwUtjFkHbu8ii2IGkvhnWonjd4w5wOldG+RPr+XoFCIaHp5TszQ+HnUTLIXKtBgzzCKjK4eZqrck7xpo5B5m5V7EUxBze2LYVky+GsDsqL8CggQqJL4ZKuZVoxgPwhnDy5nMs057NCU9EnXcauMW9UEqEHu5NXnmGJrCvQ56wjYN3lgvCHEtmIpsRjCCWaBJYiawu1J5ZAf1yGTVNh8pEvO//zL9ImUxrSfOGUeFiN1tzSFlTfbcCAwEAATANBgkqhkiG9w0BAQUFAAOCAgEAdZZpgWv79CgF5ny6HmMaYgsXJKJyQE9RhJ1cmzDY8KAF+nzT7q4Pgt3WbA9bpdji7C0WqKjX7hLipqhgFnqb8qZcodEKhX788qBj4X45+4nT6QipyJlz5x6KcCn/v9gQNKks7U+dBlqquiVfbXaa1EAKMeGtqinf+Y51nR/fBcr/P9TBnSJqH61KDO3qrE5KGTwHQ9VXoeKyeppGt5sYf8G0vwoHhtPTOO8TuLEIlFcXtzbC3zAtmQj6Su//fI5yjuYTkiayxMx8nCGrQhQSXdC8gYpYd0os7UY01DVu4BTCXEvf0GYXtiGJeG8lQT/eu7WdK83uJ93U/BMYzoq4lSVcqY4LNxlfAQXKhaAbioA5XyT7co7FQ0g+s2CGBUKa11wPDe8M2GVLPsxT2bXDQap5DQyVIuTwjtgL0tykGxPJPAnL2zuUy6T3/YzrWaJ9Os+6mUCVdLnXtDgZ10Ujel7mq6wo9Ns+u07grXZkXpmJYnJXBrwOsY8KZa5vFwgJrDXhWe+Fmgt1EP5VIqRCQAxH2iYvAaELi8udbN/ZiUU3K9t79MP/M3U/tEWAubHXsaAv03jRy43X0VjlZHmagU/4dU7RBWfyuwRarYIXLNT2FCd2z4kd3fsL3rB5iI+RH0uoNuOa1+UApfFCv0O65TYkp5jEWSlU8PhKYD43nXA=-----END CERTIFICATE-----',
     orderUrl: `orderUrl.example.com`,
@@ -50,7 +50,7 @@ export default function CertificateIndexRoute() {
           />
         ) : (
           <CertificateRequestView
-            subject={certificate.subject}
+            domain={certificate.domain}
             validFrom={certificate.validFrom}
             validTo={certificate.validTo}
             onRequest={onRequest}

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -17,6 +17,7 @@ export default function CertificateIndexRoute() {
     id: 1,
     username: 'user_test',
     domain: `user_test.example.com`,
+    status: 'issued',
     certificate:
       'Public----BEGIN CERTIFICATE-----MIIFMjCCAxoCCQCVordquLnq8TANBgkqhkiG9w0BAQUFADBbMQswCQYDVQQGEwJBVTETMBEGA1UECBMKU29tZS1TdGF0ZTEhMB8GA1UEChMYSW50ZXJuZXQgV2lkZ2l0cyBQdHkgTHRkMRQwEgYDVQQDEwtleGFtcGxlLmNvbTAeFw0xNzA5MTQxNDMzMTRaFw0xODA5MTQxNDMzMTRaMFsxCzAJBgNVBAYTAkFVMRMwEQYDVQQIEwpTb21lLVN0YXRlMSEwHwYDVQQKExhJbnRlcm5ldCBXaWRnaXRzIFB0eSBMdGQxFDASBgNVBAMTC2V4YW1wbGUuY29tMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwi2PYBNGl1n78niRGDKgcsWK03TcTeVbQ1HztA57Rr1iDHAZNx3Mv4E/Sha8VKbKoshcmUcOS3AlmbIZX+7+9c7lL2oD+vtUZF1YUR/69fWuO72wk6fKj/eofxH9Ud5KFje8qrYZdJWKkPMdWlYgjD6qpA5wl60NiuxmUr44ADZDytqHzNThN3wrFruz74PcMfakcSUMxkh98LuNeGtqHpEAw+wliko3oDD4PanvDvp5mRgiQVKHEGT7dm85Up+W1iJKJ65fkc/j940MaLbdISZYYCT5dtPgCGKCHgVuVrY+OXFJrD3TTm94ILsR/BkS/VSKNigGVPXg3q8tgIS++k13CzLUO0PNRMuod1RD9j5NEc2CVic9rcH06ugZyHlOcuVvvRsPGd52BPn+Jf1aePKPPQHxT9i5GOs80CJw0eduZCDZB32biRYNwUtjFkHbu8ii2IGkvhnWonjd4w5wOldG+RPr+XoFCIaHp5TszQ+HnUTLIXKtBgzzCKjK4eZqrck7xpo5B5m5V7EUxBze2LYVky+GsDsqL8CggQqJL4ZKuZVoxgPwhnDy5nMs057NCU9EnXcauMW9UEqEHu5NXnmGJrCvQ56wjYN3lgvCHEtmIpsRjCCWaBJYiawu1J5ZAf1yGTVNh8pEvO//zL9ImUxrSfOGUeFiN1tzSFlTfbcCAwEAATANBgkqhkiG9w0BAQUFAAOCAgEAdZZpgWv79CgF5ny6HmMaYgsXJKJyQE9RhJ1cmzDY8KAF+nzT7q4Pgt3WbA9bpdji7C0WqKjX7hLipqhgFnqb8qZcodEKhX788qBj4X45+4nT6QipyJlz5x6KcCn/v9gQNKks7U+dBlqquiVfbXaa1EAKMeGtqinf+Y51nR/fBcr/P9TBnSJqH61KDO3qrE5KGTwHQ9VXoeKyeppGt5sYf8G0vwoHhtPTOO8TuLEIlFcXtzbC3zAtmQj6Su//fI5yjuYTkiayxMx8nCGrQhQSXdC8gYpYd0os7UY01DVu4BTCXEvf0GYXtiGJeG8lQT/eu7WdK83uJ93U/BMYzoq4lSVcqY4LNxlfAQXKhaAbioA5XyT7co7FQ0g+s2CGBUKa11wPDe8M2GVLPsxT2bXDQap5DQyVIuTwjtgL0tykGxPJPAnL2zuUy6T3/YzrWaJ9Os+6mUCVdLnXtDgZ10Ujel7mq6wo9Ns+u07grXZkXpmJYnJXBrwOsY8KZa5vFwgJrDXhWe+Fmgt1EP5VIqRCQAxH2iYvAaELi8udbN/ZiUU3K9t79MP/M3U/tEWAubHXsaAv03jRy43X0VjlZHmagU/4dU7RBWfyuwRarYIXLNT2FCd2z4kd3fsL3rB5iI+RH0uoNuOa1+UApfFCv0O65TYkp5jEWSlU8PhKYD43nXA=-----END CERTIFICATE-----',
     orderUrl: `orderUrl.example.com`,
@@ -43,18 +44,13 @@ export default function CertificateIndexRoute() {
       <Flex flexDirection="column" gap="5" width="4xl">
         {certificateRequested ? (
           <CertificateAvailable
-            publicKey={certificate.certificate}
-            privateKey={certificate.privateKey}
-            validFrom={certificate.validFrom}
-            validTo={certificate.validTo}
+            publicKey={certificate.certificate!}
+            privateKey={certificate.privateKey!}
+            validFrom={certificate.validFrom!}
+            validTo={certificate.validTo!}
           />
         ) : (
-          <CertificateRequestView
-            domain={certificate.domain}
-            validFrom={certificate.validFrom}
-            validTo={certificate.validTo}
-            onRequest={onRequest}
-          />
+          <CertificateRequestView domain={certificate.domain} onRequest={onRequest} />
         )}
       </Flex>
     </Center>

--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -25,7 +25,11 @@ export const action = async ({ request }: ActionArgs) => {
   // in another form below and post.
   switch (intent) {
     case 'certificate-request':
-      await addCertRequest('testing.starchart.com');
+      // Because of the foreign key constraint, it needs to be an existing user
+      await addCertRequest({
+        username: 'starchartdev',
+        rootDomain: 'testing.starchartdev.starchart.com',
+      });
       return json({
         result: 'ok',
         message: 'Certificate requested',

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -16,7 +16,7 @@ model User {
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
   record      Record[]
-  certificate Certificate?
+  certificate Certificate[]
 }
 
 model Record {
@@ -36,15 +36,16 @@ model Record {
 }
 
 model Certificate {
-  id          Int         @id @default(autoincrement())
-  username    String      @unique
-  subject     String
-  certificate String
-  orderUrl    String      @unique @db.VarChar(255)
-  privateKey  String
-  validFrom   DateTime    @default(now())
-  validTo     DateTime
-  user        User        @relation(fields: [username], references: [username])
+  id          Int               @id @default(autoincrement())
+  username    String
+  domain      String
+  orderUrl    String            @unique @db.VarChar(255)
+  privateKey  String?
+  certificate String?
+  validFrom   DateTime?
+  validTo     DateTime?
+  status      CertificateStatus @default(pending)
+  user        User              @relation(fields: [username], references: [username])
   challenge   Challenge[]
 }
 
@@ -66,5 +67,11 @@ enum RecordType {
 enum RecordStatus {
   active
   error
+  pending
+}
+
+enum CertificateStatus {
+  failed
+  issued
   pending
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -106,13 +106,15 @@ async function seed() {
     data: {
       id: 1,
       username,
-      subject: `CN=*.${username}.example.com`,
+      domain: `*.${username}.example.com`,
       certificate:
         '-----BEGIN CERTIFICATE-----ApfFCv0O65TYkp5jEWSlU8PhKYD43nXA=-----END CERTIFICATE-----',
       orderUrl: `orderUrl.example.com`,
       privateKey:
         '-----BEGIN CERTIFICATE-----ApfFCv0O65TYkp5jEWSlU8PhKYD43nXA=-----END CERTIFICATE-----',
+      validFrom: new Date(),
       validTo: certExpDate,
+      status: 'pending',
     },
   });
 


### PR DESCRIPTION
- Moves directory url to ENV
- Alters the Let's encrypt library to not always reload challengegs, we only need that when the order is created
- Alters Prisma schema (+ seed) to comply with our needs (modified Certificate from one-to-one => one-to-many because the foreign key constraint makes testing impossible otherwise)
- Updates FE to match new db schema
- Updates related models to better match our needs
- Implements worker to handle certificate creation flow

Closes #168 