### PR TITLE
Making Certificate UI responsive

### DIFF
--- a/app/components/certificate/certificate-available.tsx
+++ b/app/components/certificate/certificate-available.tsx
@@ -4,15 +4,15 @@ import Description from './description';
 import CertificateDisplay from './certificate-display';
 
 interface CertificateAvailableProps {
-  validFrom: Date;
-  validTo: Date;
+  validFromFormatted: string;
+  validToFormatted: string;
   publicKey: string;
   privateKey: string;
 }
 
 export default function CertificateAvailable({
-  validFrom,
-  validTo,
+  validFromFormatted,
+  validToFormatted,
   publicKey,
   privateKey,
 }: CertificateAvailableProps) {
@@ -21,8 +21,8 @@ export default function CertificateAvailable({
       <Description
         description="Certificate: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s"
         certRequested={true}
-        validFrom={validFrom}
-        validTo={validTo}
+        validFromFormatted={validFromFormatted}
+        validToFormatted={validToFormatted}
       />
       <Divider />
       <CertificateDisplay

--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -34,66 +34,71 @@ export default function CertificateDisplay({ title, description, value }: Certif
   }
 
   return (
-    <Flex flexDirection="column" gap="5">
-      <Flex flexDirection="column" gap="4">
-        <HStack gap="4">
-          <Heading as="h4" size="sm">
-            {title}
-          </Heading>
-          <Tooltip label={`Copy ${title}`}>
-            <IconButton
-              backgroundColor="transparent"
-              color="black"
-              size="xs"
-              _hover={{
-                background: 'whitesmoke',
-                color: 'teal.500',
-              }}
-              aria-label="Copy to Clipboard"
-              icon={<CopyIcon fontSize="md" />}
-              onClick={() => onCopy()}
-            />
-          </Tooltip>
-          <Tooltip label={`Download ${title}`}>
-            <IconButton
-              backgroundColor="transparent"
-              color="black"
-              size="xs"
-              _hover={{
-                background: 'brand.500',
-                color: 'white',
-              }}
-              aria-label="Download"
-              icon={
-                <DownloadIcon
-                  fontSize="md"
-                  onClick={() =>
-                    toast({
-                      title: `Downloading ${title}`,
-                      position: 'bottom-right',
-                      status: 'success',
-                    })
-                  }
-                />
-              }
-            />
-          </Tooltip>
-        </HStack>
-        <Text>{description}</Text>
-        <Accordion allowMultiple>
-          <AccordionItem>
-            <AccordionButton>
-              <Box as="span" flex="1" textAlign="left">
-                Show/Hide
-              </Box>
-              <AccordionIcon />
-            </AccordionButton>
-            <AccordionPanel>
-              <Text>{value}</Text>
-            </AccordionPanel>
-          </AccordionItem>
-        </Accordion>
-      </Flex>
+    <Flex
+      flexDirection="column"
+      gap="4"
+      textAlign={{ base: 'center', md: 'left' }}
+      fontSize={{ base: 'sm', md: 'md' }}
+    >
+      <HStack gap="4" alignSelf={{ base: 'center', md: 'flex-start' }}>
+        <Heading as="h4" size="sm">
+          {title}
+        </Heading>
+        <Tooltip label={`Copy ${title}`}>
+          <IconButton
+            backgroundColor="transparent"
+            color="black"
+            size="xs"
+            _hover={{
+              background: 'whitesmoke',
+              color: 'teal.500',
+            }}
+            aria-label="Copy to Clipboard"
+            icon={<CopyIcon fontSize="md" />}
+            onClick={() => onCopy()}
+          />
+        </Tooltip>
+        <Tooltip label={`${title} is Downloaded`}>
+          <IconButton
+            backgroundColor="transparent"
+            color="black"
+            size="xs"
+            _hover={{
+              background: 'brand.500',
+              color: 'white',
+            }}
+            aria-label="Download"
+            icon={
+              <DownloadIcon
+                fontSize="md"
+                onClick={() =>
+                  toast({
+                    title: `${title} is Downloaded`,
+                    position: 'bottom-right',
+                    status: 'success',
+                  })
+                }
+              />
+            }
+          />
+        </Tooltip>
+      </HStack>
+      <Text>{description}</Text>
+      <Accordion allowMultiple>
+        <AccordionItem>
+          <AccordionButton>
+            <Box as="span" flex="1">
+              Show/Hide
+            </Box>
+            <AccordionIcon />
+          </AccordionButton>
+          <AccordionPanel>
+            <Flex justifyContent="center">
+              <Text maxWidth={{ base: '3xs', xs: 'xs', sm: 'md', md: 'full' }}>{value}</Text>
+            </Flex>
+          </AccordionPanel>
+        </AccordionItem>
+      </Accordion>
     </Flex>
   );
 }

--- a/app/components/certificate/certificate-request.tsx
+++ b/app/components/certificate/certificate-request.tsx
@@ -1,4 +1,4 @@
-import { Flex, Heading, Text, HStack, Button } from '@chakra-ui/react';
+import { Flex, Heading, Text, Button } from '@chakra-ui/react';
 
 import Description from './description';
 
@@ -9,22 +9,36 @@ interface CertificateRequestViewProps {
 
 export default function CertificateRequestView({ domain, onRequest }: CertificateRequestViewProps) {
   return (
-    <Flex flexDirection="column" gap="5" width="4xl">
+    <Flex
+      flexDirection="column"
+      gap="5"
+      alignItems={{ base: 'center', md: 'flex-start' }}
+      paddingX="1"
+    >
       <Description
         description="Initial: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s"
         certRequested={false}
       />
-      <Flex flexDirection="column" gap="1">
-        <Heading as="h3" size="md" marginBottom="3">
+      <Flex
+        flexDirection="column"
+        fontSize={{ base: 'sm', md: 'md' }}
+        gap={{ base: '3', md: '' }}
+        alignItems={{ base: 'center', md: 'flex-start' }}
+        textAlign={{ base: 'center', md: 'left' }}
+      >
+        <Heading as="h3" size={{ base: 'sm', md: 'md' }}>
           Domain Name
         </Heading>
         <Text>Lorem Ipsum is simply dummy text of the printing and typesetting industry</Text>
-
-        <HStack>
-          <Text fontWeight="bold">Domain Name:</Text> <Text>{domain}</Text>
-        </HStack>
+        <Flex
+          flexDirection={{ base: 'column', md: 'row' }}
+          alignItems={{ base: 'center', md: 'flex-start' }}
+        >
+          <Text fontWeight="bold">Domain Name:&nbsp;</Text>
+          <Text>{domain}</Text>
+        </Flex>
       </Flex>
-      <Button width="3xs" shadow="xl" onClick={onRequest}>
+      <Button width={{ base: 'full', md: '3xs' }} shadow="xl" onClick={onRequest}>
         Request a Certificate
       </Button>
     </Flex>

--- a/app/components/certificate/description.tsx
+++ b/app/components/certificate/description.tsx
@@ -2,34 +2,41 @@ import { Flex, Heading, Text, HStack, VStack } from '@chakra-ui/react';
 
 interface DescriptionSectionProps {
   certRequested: boolean;
-  validFrom?: Date;
-  validTo?: Date;
+  validFromFormatted?: string;
+  validToFormatted?: string;
   description: string;
 }
 
 export default function DescriptionSection({
   certRequested,
-  validFrom,
-  validTo,
+  validFromFormatted,
+  validToFormatted,
   description,
 }: DescriptionSectionProps) {
   return (
-    <Flex flexDirection="column" gap="3" marginTop="14">
-      <Heading as="h1" size="xl">
+    <Flex
+      flexDirection="column"
+      gap="3"
+      marginTop={{ base: '5', md: '14' }}
+      fontSize={{ base: 'sm', md: 'md' }}
+      alignItems={{ base: 'center', md: 'flex-start' }}
+      textAlign={{ base: 'center', md: 'left' }}
+    >
+      <Heading as="h1" size={{ base: 'lg', md: 'xl' }}>
         Certificate
       </Heading>
       <Text>{description}</Text>
       {certRequested && (
         <HStack gap="6" marginTop="2">
-          {!!validFrom && !!validTo && (
+          {!!validFromFormatted && !!validToFormatted && (
             <>
               <VStack>
                 <Text fontWeight="bold">Created On</Text>
-                <Text>{validFrom.toDateString()}</Text>
+                <Text>{validFromFormatted}</Text>
               </VStack>
               <VStack>
                 <Text fontWeight="bold">Expires On</Text>
-                <Text>{validTo.toDateString()}</Text>
+                <Text>{validToFormatted}</Text>
               </VStack>
             </>
           )}

--- a/app/components/certificate/loading.tsx
+++ b/app/components/certificate/loading.tsx
@@ -1,15 +1,24 @@
-import { Center, Flex, Box, Image, Heading } from '@chakra-ui/react';
+import { Center, Flex, Image, Heading } from '@chakra-ui/react';
 
 import undrawSvg from '~/assets/undraw_processing_re_tbdu.svg';
 
 export default function LoadingView() {
   return (
-    <Center paddingY="24">
-      <Flex flexDirection="column" width="5xl" textAlign="center" gap="5">
-        <Box>
-          <Image src={undrawSvg} />
-        </Box>
-        <Heading as="h2" size="xl" fontFamily="heading" fontWeight="light" color="brand.500">
+    <Center paddingY="24" paddingX="2">
+      <Flex
+        flexDirection="column"
+        width={{ base: 'lg', sm: '2xl', md: '5xl' }}
+        textAlign="center"
+        gap="5"
+      >
+        <Image src={undrawSvg} />
+        <Heading
+          as="h2"
+          size={{ base: 'md', sm: 'lg', md: 'xl' }}
+          fontFamily="heading"
+          fontWeight="light"
+          color="brand.500"
+        >
           We have received your request, and will notify you when your certificate is ready
         </Heading>
       </Flex>

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -35,7 +35,7 @@ export default function Header() {
       paddingX={{ base: '1', md: '10' }}
       justifyContent="space-between"
     >
-      <Hide below="md">
+      <Hide below="lg">
         <HStack color="white" justifyContent="flex-start">
           <Link to={{ pathname: '/domains' }}>
             <Flex alignItems="center">
@@ -52,7 +52,7 @@ export default function Header() {
           </Link>
         </HStack>
       </Hide>
-      <Show below="md">
+      <Show below="lg">
         <Menu>
           <MenuButton
             as={Button}
@@ -81,11 +81,11 @@ export default function Header() {
         </Menu>
       </Show>
 
-      <Heading as="h1" size={{ base: 'md', sm: 'xl' }} color="white">
+      <Heading as="h1" size={{ base: 'md', xs: 'lg', sm: 'xl' }} color="white">
         My.Custom.Domain
       </Heading>
       <Flex justifyContent="flex-end" alignItems="center" color="white" gap="5">
-        <Hide below="md">
+        <Hide below="lg">
           <Text>{user.username}</Text>
         </Hide>
 

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -35,19 +35,29 @@ export default function CertificateIndexRoute() {
     }, 5000);
   }
 
+  function formatDate(val: Date): string {
+    let date = val.toLocaleDateString('en-US', {
+      month: 'short',
+      day: '2-digit',
+      year: 'numeric',
+    });
+
+    return date;
+  }
+
   if (loading) {
     return <Loading />;
   }
 
   return (
     <Center>
-      <Flex flexDirection="column" gap="5" width="4xl">
+      <Flex flexDirection="column" gap="5" width={{ base: 'md', sm: 'lg', md: '2xl', lg: '4xl' }}>
         {certificateRequested ? (
           <CertificateAvailable
             publicKey={certificate.certificate!}
             privateKey={certificate.privateKey!}
-            validFrom={certificate.validFrom!}
-            validTo={certificate.validTo!}
+            validFromFormatted={formatDate(certificate.validFrom!)}
+            validToFormatted={formatDate(certificate.validTo!)}
           />
         ) : (
           <CertificateRequestView domain={certificate.domain} onRequest={onRequest} />

--- a/app/theme/breakpoints.ts
+++ b/app/theme/breakpoints.ts
@@ -1,0 +1,10 @@
+const breakpoints = {
+  'xs': '20em',
+  'sm': '30em',
+  'md': '48em',
+  'lg': '62em',
+  'xl': '80em',
+  '2xl': '96em',
+};
+
+export default breakpoints;

--- a/app/theme/index.ts
+++ b/app/theme/index.ts
@@ -1,9 +1,11 @@
 import { extendTheme, withDefaultColorScheme } from '@chakra-ui/react';
 import colors from './colors';
+import breakpoints from './breakpoints';
 
 const theme = extendTheme(
   {
     colors,
+    breakpoints,
     styles: {
       global: {
         '.domain-form': {


### PR DESCRIPTION
I added an `xs` breakpoint, because there are far too much space in between `base` and `sm` around `30em`, and some devices are between those which did cause an issue when trying to scale down some of the UI.

Here's a demo of the UI **(Updated)**:

https://user-images.githubusercontent.com/32577022/220522777-9882826a-65f5-4e45-8e05-f852c7eadfc3.mp4

If you noticed having some white spaces in the header, unfortunately unless I hard coded specifically to accommodate for that specific resolution, that white spot can occur. On the other hand, the UI should work perfectly with most devices

Close #252 
