### PR TITLE
chore: add tsdoc for demo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,13 +2,13 @@
 
 <!-- vim-markdown-toc GFM -->
 
-- [Contributing guidelines](#contributing-guidelines)
-  - [Development](#development)
-    - [System prerequisites](#system-prerequisites)
-    - [Dev environment set up](#dev-environment-set-up)
-  - [Pull requests](#pull-requests)
-  - [Merging to main](#merging-to-main)
-    - [Stages: Draft and Ready for review](#stages-draft-and-ready-for-review)
+- [Development](#development)
+  - [System prerequisites](#system-prerequisites)
+  - [Dev environment set up](#dev-environment-set-up)
+- [Pull requests](#pull-requests)
+- [Merging to main](#merging-to-main)
+  - [Stages: Draft and Ready for review](#stages-draft-and-ready-for-review)
+- [Code style](#code-style)
 
 <!-- vim-markdown-toc -->
 
@@ -78,3 +78,22 @@ Pull requests have two stages: Draft and Ready for review.
    - You can skip this if your PR is ready for review.
 2. Change your PR to ready when the PR is ready for review.
    - You can convert back to Draft at any time.
+
+## Code style
+
+- All code styles should adhere to prettier code style. There are pre commit hooks that runs prettier on the entire code base.
+- It is strongly encouraged to write documentation in the [tsdoc](https://tsdoc.org/) where it makes sense.
+
+```ts
+/**
+ * Returns the average of two numbers.
+ *
+ * @param x - The first input number
+ * @param y - The second input number
+ * @returns The arithmetic mean of `x` and `y`
+ *
+ */
+function getAverage(x: number, y: number): number {
+  return (x + y) / 2.0;
+}
+```

--- a/app/lib/notifications.server.ts
+++ b/app/lib/notifications.server.ts
@@ -1,11 +1,16 @@
 import { createTransport } from 'nodemailer';
 import { secrets } from 'docker-secret';
 import logger from './logger.server';
+import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 const { NOTIFICATIONS_EMAIL_USER, NODE_ENV, MAILHOG_SMTP_PORT } = process.env;
 const { NOTIFICATIONS_USERNAME, NOTIFICATIONS_PASSWORD } = secrets ?? {};
 
-const initializeTransport = () => {
+/**
+ * Initializes the nodemailer transport
+ * @returns Nodemailer transport
+ */
+function initializeTransport() {
   if (!NOTIFICATIONS_EMAIL_USER) {
     throw new Error('Missing Nodemailer user. Skipping nodemailer configuration');
   }
@@ -28,9 +33,20 @@ const initializeTransport = () => {
   return createTransport({
     port: Number(MAILHOG_SMTP_PORT || '1025'),
   });
-};
+}
 
-const sendNotification = async (emailAddress: string, subject: string, text: string) => {
+/**
+ * sends an email notification
+ * @param emailAddress - the email address to send notifications to
+ * @param subject - the subject of the email
+ * @param text - the body of the email
+ * @returns a promise containing send message info, or undefined if the message was not sent successfully
+ */
+async function sendNotification(
+  emailAddress: string,
+  subject: string,
+  text: string
+): Promise<SMTPTransport.SentMessageInfo | undefined> {
   try {
     const transport = initializeTransport();
     logger.debug(`Sending notification to ${emailAddress}`);
@@ -43,6 +59,6 @@ const sendNotification = async (emailAddress: string, subject: string, text: str
   } catch (error) {
     logger.warn('Unable to send notification', error);
   }
-};
+}
 
 export default sendNotification;


### PR DESCRIPTION
This is a demo as to why we should "strongly encourage" proper documentation in the starchart codebase

As a developer using this library code, or code written by other people, I do not want to:

- Read through the function code to understand the logic
- Read through the tests to understand the usage of the code

I want to:

- At a glance tell what the function does
- What each of the arguments do/mean

When developing or browsing the code base, using tools like the LSP can also help in understanding the code. Example using "on hover"

![image](https://user-images.githubusercontent.com/55592708/220528373-2918867f-d1f6-4e23-917b-ffe2539cb2cf.png)

## The solution

This is something we could "strongly enforce" (place a note in the `CONTRIBUTING.md`, and people should keep an eye on in code reviews), but not something we say all devs must follow.

Due to the "cultural" differences in each year of the open source class, enforcing excessive policies means they will eventually go unenforced. But there is a fine line between cultural differences and enforcing good coding practices for the sake of scalability and maintainability.
