### PR TITLE
Remove unnecessary ioredis types stub

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,6 @@
         "@types/cors": "^2.8.13",
         "@types/eslint": "^8.4.10",
         "@types/express": "^4.17.16",
-        "@types/ioredis": "^5.0.0",
         "@types/node": "^18.14.0",
         "@types/nodemailer": "^6.4.7",
         "@types/react": "^18.0.28",
@@ -6654,16 +6653,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
       "dev": true
-    },
-    "node_modules/@types/ioredis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
-      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
-      "deprecated": "This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.",
-      "dev": true,
-      "dependencies": {
-        "ioredis": "*"
-      }
     },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
@@ -26421,15 +26410,6 @@
       "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
       "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
       "dev": true
-    },
-    "@types/ioredis": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@types/ioredis/-/ioredis-5.0.0.tgz",
-      "integrity": "sha512-zJbJ3FVE17CNl5KXzdeSPtdltc4tMT3TzC6fxQS0sQngkbFZ6h+0uTafsRqu+eSLIugf6Yb0Ea0SUuRr42Nk9g==",
-      "dev": true,
-      "requires": {
-        "ioredis": "*"
-      }
     },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,6 @@
     "@types/cors": "^2.8.13",
     "@types/eslint": "^8.4.10",
     "@types/express": "^4.17.16",
-    "@types/ioredis": "^5.0.0",
     "@types/node": "^18.14.0",
     "@types/nodemailer": "^6.4.7",
     "@types/react": "^18.0.28",


### PR DESCRIPTION
I noticed that we don't need the ioredis stub types (they are built-in now):

```sh
$ npm ci
npm WARN deprecated @types/ioredis@5.0.0: This is a stub types definition. ioredis provides its own type definitions, so you do not need this installed.
```