### PR TITLE
Add DEPLOY.md with initial config info, s/MAILHOG_SMTP_PORT/SMTP_PORT/

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,6 @@ PORT=8080
 # One of: trace, debug, info, warn, error, fatal, silent
 LOG_LEVEL=debug
 
-# Nodemailer config
+# Notifications Email Config
 NOTIFICATIONS_EMAIL_USER="no-reply@senecacollege.ca"
-MAILHOG_SMTP_PORT=1025
+SMTP_PORT=1025

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,43 @@
+# Deployment
+
+Startchart depends on a number of external services, including:
+
+1. MySQL
+2. Amazon Route53
+3. An SMTP Server
+4. A Redis Server
+5. Let's Encrypt
+6. SAML2 IdP (e.g., Azure Active Directory)
+
+## Configuration
+
+A number of environment variables and Docker secrets are required at runtime.
+
+### Environment Variables
+
+The following configuration values must be set via environment variables.
+
+| Variable Name                | Description                                                                                                                                                                        |
+| ---------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PORT`                       | The server runs on port `8080` by default                                                                                                                                          |
+| `LOG_LEVEL`                  | The log level to use for log messages. One of `error`, `debug`, `info`, etc. See [Winston docs](https://github.com/winstonjs/winston#logging-levels). Defaults to `info`           |
+| `ROOT_DOMAIN`                | The DNS root domain for the hosted zone (e.g., `starchart.com`)                                                                                                                    |
+| `AWS_ROUTE53_HOSTED_ZONE_ID` | The existing Amazon Route53 Hosted Zone ID to use (e.g., `Z23ABC4XYZL05B`)                                                                                                         |
+| `NOTIFICATIONS_EMAIL_USER`   | The email address from which notifications are sent                                                                                                                                |
+| `SMTP_PORT`                  | The port to use for the SMTP server. Defaults to `587` in production (using `smtp.office365.com`) and `1025` in development (using ([MailHog](https://github.com/mailhog/MailHog)) |
+| `LETS_ENCRYPT_ACCOUNT_EMAIL` | The email address to use for the app's [single Let's Encrypt account](https://letsencrypt.org/docs/integration-guide/#one-account-or-many)                                         |
+| `REDIS_URL`                  | The Redis server to use for the worker queues. Defaults to `redis://redis:6379` in production and `localhost:6379` in development.                                                 |
+| `SECRETS_OVERRIDE`           | In development, to override the Docker secrets                                                                                                                                     |
+
+### Secrets
+
+The following secrets must be added to the Docker engine using [Docker Swarm secrets](https://docs.docker.com/engine/swarm/secrets/).
+
+| Secret Name                            | Description                                                      |
+| -------------------------------------- | ---------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`                    | The AWS Account Access Key ID for use with Route 53              |
+| `AWS_SECRET_ACCESS_KEY`                | The AWS Account Secret Access Key for use with Route 53          |
+| `LETS_ENCRYPT_ACCOUNT_PRIVATE_KEY_PEM` | The RSA Private Key for the Let's Encrypt account, in PEM format |
+| `SESSION_SECRET`                       | The long, random string to use for keying sessions               |
+| `NOTIFICATIONS_USERNAME`               | The SMTP username to use for sending notifications               |
+| `NOTIFICATIONS_PASSWORD`               | The SMTP password to use for sending notifications               |

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Centre for the Development of Open Technology
+Copyright (c) 2022, 2023 Centre for the Development of Open Technology
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Starchart
+# Starchart [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Starchart makes it easy for the Seneca developer community to create and manager their own custom subdomains and SSL certificates, without cost or having to provide personal information.
+
+For information about running Starchart, see our [deployment guide](DEPLOY.md). For development information, see our [contributing guide](CONTRIBUTING.md). For further technical background, planning, and initial designs, please see the [wiki](https://github.com/Seneca-CDOT/starchart/wiki).
 
 ## Introduction
 
@@ -34,9 +36,3 @@ Here is the planned architecture and [technologies used](https://github.com/Sene
 ![components](img/Starchart%20architecture.drawio.png)
 
 ## Development
-
-- Further technical background, planning, and initial designs are available in the [wiki](https://github.com/Seneca-CDOT/starchart/wiki).
-
-- If you would like to contribute, please see how to [here](CONTRIBUTING.md).
-
-- You can find the license [here](LICENSE).

--- a/app/lib/notifications.server.ts
+++ b/app/lib/notifications.server.ts
@@ -3,7 +3,7 @@ import { createTransport } from 'nodemailer';
 import secrets from '~/lib/secrets.server';
 import logger from './logger.server';
 
-const { NOTIFICATIONS_EMAIL_USER, NODE_ENV, MAILHOG_SMTP_PORT } = process.env;
+const { NOTIFICATIONS_EMAIL_USER, NODE_ENV, SMTP_PORT } = process.env;
 const { NOTIFICATIONS_USERNAME, NOTIFICATIONS_PASSWORD } = secrets;
 
 const initializeTransport = () => {
@@ -27,7 +27,7 @@ const initializeTransport = () => {
     });
   }
   return createTransport({
-    port: Number(MAILHOG_SMTP_PORT || '1025'),
+    port: Number(SMTP_PORT || '1025'),
   });
 };
 


### PR DESCRIPTION
Getting ready for #43, and to help document what I did in #254, this adds a `DEPLOY.md` doc.  It will include instructions on how to deploy and run the app in production.

Currently, I only have the info you need about all our various environment variables and secrets, but I'll add more in the coming weeks.

This should also help other devs understand what all these are about.  If we add more variables/secrets, let's ask people to update this doc.

NOTE: I also changed the `MAILHOG_SMTP_PORT` to `SMTP_PORT`