### PR TITLE
Don't force insecure requests to upgrade to HTTPS for dev/testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "db:studio": "prisma studio",
     "setup": "run-s db:generate db:push db:seed",
     "start": "cross-env NODE_ENV=production node ./build/server.js",
-    "start:e2e": "cross-env NODE_ENV=production node --require dotenv/config ./build/server.js",
+    "start:e2e": "cross-env NODE_ENV=testing node --require dotenv/config ./build/server.js",
     "test": "cross-env SECRETS_OVERRIDE=1 NODE_OPTIONS=--require=dotenv/config vitest",
     "test:e2e:dev": "cross-env PORT=8080 start-server-and-test dev http://localhost:8080 \"playwright test\"",
     "pretest:e2e:run": "cross-env SECRETS_OVERRIDE=1 run-s build",

--- a/server.ts
+++ b/server.ts
@@ -19,6 +19,7 @@ import {
 
 import type { Request, Response } from 'express';
 
+const MODE = process.env.NODE_ENV;
 const app = express();
 
 app.use((_req, res, next) => {
@@ -34,7 +35,9 @@ app.use(
         // Expect a nonce on scripts
         scriptSrc: ["'self'", (_req, res) => `'nonce-${(res as Response).locals.nonce}'`],
         // Allow live reload to work over a web socket in development
-        connectSrc: process.env.NODE_ENV === 'production' ? ["'self'"] : ["'self'", 'ws:'],
+        connectSrc: MODE === 'production' ? ["'self'"] : ["'self'", 'ws:'],
+        // Don't force https unless in production
+        upgradeInsecureRequests: MODE === 'production' ? [] : null,
       },
     },
   })
@@ -62,7 +65,6 @@ app.use('/build', express.static('public/build', { immutable: true, maxAge: '1y'
 // more aggressive with this caching.
 app.use(express.static('public', { maxAge: '1h' }));
 
-const MODE = process.env.NODE_ENV;
 const BUILD_DIR = path.join(process.cwd(), 'build');
 // Pass the nonce we're setting in the CSP headers down to the Remix Loader/Action functions
 const getLoadContext = (_req: Request, res: Response) => ({ nonce: res.locals.nonce });


### PR DESCRIPTION
Fixes #244.  This alters our CSP settings to not force HTTP origins to be upgraded to HTTPS unless we are in production.  For local dev and testing (CI), we'll use HTTP.  I've also changed the way the app runs in e2e tests so it doesn't use `production` either. 

To test this, run the server and load using Safari.  If you can login, it works.