### PR TITLE
Fix dev run script for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "run-s build:*",
     "build:remix": "remix build",
     "build:server": "esbuild --platform=node --format=cjs ./server.ts --outdir=build --bundle",
-    "dev": "SECRETS_OVERRIDE=1 run-p dev:*",
+    "dev": "cross-env SECRETS_OVERRIDE=1 run-p dev:*",
     "dev:build": "cross-env NODE_ENV=development npm run build:server -- --watch",
     "dev:remix": "cross-env NODE_ENV=development remix watch",
     "dev:server": "cross-env NODE_ENV=development node --inspect --require ./node_modules/dotenv/config ./build/server.js",


### PR DESCRIPTION
Fixes #266 

Added `cross-env` to script so that `npm run dev` works on windows