### PR TITLE
ci: autogenerate release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - '*.*.*'
+      - '*'
 
 jobs:
   Release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
     # needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
     steps:
       - name: Generate release
-        uses: 'marvinpinto/action-automatic-releases@latest'
+        uses: 'marvinpinto/action-automatic-releases@v1.2.1'
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
           automatic_release_tag: 'latest'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - 'v*'
+      - '*.*.*'
 
 jobs:
   Release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,18 @@ jobs:
     # TODO: not sure if this will work
     # needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
     steps:
+      - name: Set output
+        id: vars
+        run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
+      - name: Check output
+        env:
+          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
+        run: |
+          echo $RELEASE_VERSION
+          echo ${{ steps.vars.outputs.tag }}
       - name: Generate release
         uses: 'marvinpinto/action-automatic-releases@v1.2.1'
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
           automatic_release_tag: 'latest'
           prerelease: false
-          # title: "Development Build"

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     # don't allow for publishing release unless everything else passes
     # TODO: not sure if this will work
-    needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
+    # needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
     steps:
       - name: Generate release
         uses: 'marvinpinto/action-automatic-releases@latest'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,18 +12,12 @@ jobs:
     # TODO: not sure if this will work
     # needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
     steps:
-      - name: Set output
+      - name: Get tag version
         id: vars
         run: echo "tag=${GITHUB_REF#refs/*/}" >> $GITHUB_OUTPUT
-      - name: Check output
-        env:
-          RELEASE_VERSION: ${{ steps.vars.outputs.tag }}
-        run: |
-          echo $RELEASE_VERSION
-          echo ${{ steps.vars.outputs.tag }}
       - name: Generate release
         uses: 'marvinpinto/action-automatic-releases@v1.2.1'
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          automatic_release_tag: 'latest'
+          automatic_release_tag: ${{ steps.vars.outputs.tag }}
           prerelease: false

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  Release:
+    runs-on: ubuntu-latest
+    # don't allow for publishing release unless everything else passes
+    # TODO: not sure if this will work
+    needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
+    steps:
+      - name: Generate release
+        uses: 'marvinpinto/action-automatic-releases@latest'
+        with:
+          repo_token: '${{ secrets.GITHUB_TOKEN }}'
+          automatic_release_tag: 'latest'
+          prerelease: false
+          # title: "Development Build"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@senecacdot/starchart",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.276.0",
         "@chakra-ui/icons": "^2.0.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@senecacdot/starchart",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.276.0",
         "@chakra-ui/icons": "^2.0.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@senecacdot/starchart",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.276.0",
         "@chakra-ui/icons": "^2.0.17",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@senecacdot/starchart",
-      "version": "0.4.1",
+      "version": "0.4.2",
       "dependencies": {
         "@aws-sdk/client-route-53": "^3.276.0",
         "@chakra-ui/icons": "^2.0.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "sideEffects": false,
   "scripts": {
     "build": "run-s build:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "sideEffects": false,
   "scripts": {
     "build": "run-s build:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "sideEffects": false,
   "scripts": {
     "build": "run-s build:*",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@senecacdot/starchart",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "sideEffects": false,
   "scripts": {
     "build": "run-s build:*",


### PR DESCRIPTION
Closes #249

A GitHub actions to auto generate a release tag upon the push of a new tag
