### PR TITLE
Seed 2 test users

### DIFF
--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -19,13 +19,17 @@ async function seed() {
   await prisma.certificate.deleteMany().catch(() => {});
   await prisma.user.deleteMany().catch(() => {});
 
-  await prisma.user.create({
-    data: {
-      username,
-      firstName,
-      lastName,
-      email,
-    },
+  await prisma.user.createMany({
+    data: [
+      {
+        username,
+        firstName,
+        lastName,
+        email,
+      },
+      { username: 'user1', firstName: 'Johannes', lastName: 'Kepler', email: 'user1@myseneca.ca' },
+      { username: 'user2', firstName: 'Galileo', lastName: 'Galilei', email: 'user2@myseneca.ca' },
+    ],
   });
 
   await prisma.record.createMany({


### PR DESCRIPTION
Closes #175 
This PR adds two more users to for seeding in `seed.ts` according to PR #174 as follow-up.

## Test
You can use `npm run db:seed` to seed, and then use `npm run db:studio` to see whether the users are created.
They should also be present after setting up a new instance of the project locally, since `npm run setup` will be used.