### PR TITLE
Only add final exception logging once, increase emitter max

### DIFF
--- a/app/lib/logger.server.ts
+++ b/app/lib/logger.server.ts
@@ -15,16 +15,20 @@ const logger = winston.createLogger({
   transports: [new winston.transports.Console()],
 });
 
-// https://nodejs.org/api/process.html#event-uncaughtexception
-process.on('uncaughtException', (err, origin) => {
-  logger.error('uncaughtException', err, origin);
-  throw err;
-});
+export async function init() {
+  logger.debug(`logger init: adding logging for unhandled process errors`);
 
-// https://nodejs.org/api/process.html#event-unhandledrejection
-process.on('unhandledRejection', (reason, promise) => {
-  logger.error('unhandledRejection', reason, promise);
-  throw reason;
-});
+  // https://nodejs.org/api/process.html#event-uncaughtexception
+  process.on('uncaughtException', (err, origin) => {
+    logger.error(`uncaughtException: origin=${origin}`, err);
+    throw err;
+  });
+
+  // https://nodejs.org/api/process.html#event-unhandledrejection
+  process.on('unhandledRejection', (reason) => {
+    logger.error(`unhandledRejection:`, reason);
+    throw reason;
+  });
+}
 
 export default logger;

--- a/app/lib/redis.server.ts
+++ b/app/lib/redis.server.ts
@@ -6,7 +6,7 @@ import type { Redis as RedisType, RedisOptions } from 'ioredis';
 // Using Redis means we'll need a lot more event listeners for BullMQ
 // or we will hit the default max limit of 10 listeners. The preferred
 // fix for this warning is to increase that default.
-EventEmitter.defaultMaxListeners = 32;
+EventEmitter.defaultMaxListeners = 64;
 
 let redis: RedisType;
 

--- a/server.ts
+++ b/server.ts
@@ -7,7 +7,7 @@ import gracefulShutdown from 'http-graceful-shutdown';
 import helmet from 'helmet';
 import cors from 'cors';
 
-import logger from '~/lib/logger.server';
+import logger, { init as loggerInit } from '~/lib/logger.server';
 import { notificationsWorker } from '~/queues/notifications.server';
 import { init as samlInit } from '~/lib/saml.server';
 import { init as dnsInit } from '~/lib/dns.server';
@@ -91,7 +91,7 @@ app.all(
 // happen here.
 async function init() {
   logger.info('app initializing...');
-  return Promise.all([samlInit(), dnsInit()]);
+  return Promise.all([loggerInit(), samlInit(), dnsInit()]);
 }
 
 async function start() {


### PR DESCRIPTION
This fixes 2 things:

1. Increases the max for registering event emitter listeners. We get all kinds of warnings due to how BullMQ works
2. Only registers the handlers for logging fatal errors once, which helps with 1. too

