### PR TITLE
feat: DNS propagation wait worker

### DIFF
--- a/app/lib/dns.server.ts
+++ b/app/lib/dns.server.ts
@@ -113,11 +113,23 @@ export const upsertRecord = async (
 ) => {
   try {
     if (!isNameValid(name, username)) {
-      throw new Error('Invalid name provided');
+      logger.error('Invalid record name provided', {
+        name,
+        username,
+        baseDomian: `${username}.${process.env.ROOT_DOMAIN}`,
+      });
+
+      throw new Error('Invalid record name provided');
     }
 
     if (!isValueValid(type, value)) {
-      throw new Error('Invalid value provided');
+      logger.error('Invalid record value provided', {
+        name,
+        username,
+        type,
+        value,
+      });
+      throw new Error('Invalid record value provided');
     }
 
     const command = new ChangeResourceRecordSetsCommand({
@@ -226,8 +238,8 @@ export const getChangeStatus = async (changeId: string) => {
 export const isNameValid = (name: string, username: string) => {
   const rootDomain = process.env.ROOT_DOMAIN!;
 
-  /* Domain name must end with username and root domain. 
-  Here it removes username and root domain, 
+  /* Domain name must end with username and root domain.
+  Here it removes username and root domain,
   to validate only subdomain that user has input */
   const toRemove = `.${username}.${rootDomain}`;
   if (!name.endsWith(toRemove)) {

--- a/app/lib/dns.server.ts
+++ b/app/lib/dns.server.ts
@@ -9,6 +9,7 @@ import isIP from 'validator/lib/isIP';
 
 import logger from '~/lib/logger.server';
 import secrets from '~/lib/secrets.server';
+import { buildUserBaseDomain } from '~/utils';
 
 import type {
   CreateHostedZoneResponse,
@@ -116,7 +117,7 @@ export const upsertRecord = async (
       logger.error('Invalid record name provided', {
         name,
         username,
-        baseDomian: `${username}.${process.env.ROOT_DOMAIN}`,
+        baseDomain: buildUserBaseDomain(username),
       });
 
       throw new Error('Invalid record name provided');
@@ -236,12 +237,12 @@ export const getChangeStatus = async (changeId: string) => {
 4. Domain name cannot contain multiple consecutive '-' or '_'
 5. Domain name can contain uppercase in UI but it is converted to lowercase before validation */
 export const isNameValid = (name: string, username: string) => {
-  const rootDomain = process.env.ROOT_DOMAIN!;
+  const baseDomain = buildUserBaseDomain(username);
 
   /* Domain name must end with username and root domain.
   Here it removes username and root domain,
   to validate only subdomain that user has input */
-  const toRemove = `.${username}.${rootDomain}`;
+  const toRemove = `.${baseDomain}`;
   if (!name.endsWith(toRemove)) {
     return false;
   }

--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -144,11 +144,25 @@ class LetsEncrypt {
   }): Promise<boolean> => {
     const resolver = await getAuthoritativeResolverForDomain(domain);
 
-    const txtRecords = (await resolver.resolveTxt(domain))
-      // Flatten array of arrays
-      .flat();
+    let txtRecords;
 
-    return txtRecords.includes(key);
+    try {
+      txtRecords = (await resolver.resolveTxt(domain))
+        // Flatten array of arrays
+        .flat();
+    } catch (e) {
+      /**
+       * Noop, this is expected
+       * example: {
+       *   errno: undefined,
+       *   code: 'ENODATA',
+       *   syscall: 'queryTxt',
+       *   hostname: '_acme-challenge.testing.user1.starchart.com'
+       * }
+       */
+    }
+
+    return txtRecords?.includes(key) ?? false;
   };
 
   /**

--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -150,6 +150,8 @@ class LetsEncrypt {
       txtRecords = (await resolver.resolveTxt(domain))
         // Flatten array of arrays
         .flat();
+
+      return txtRecords.includes(key);
     } catch (e) {
       /**
        * Noop, this is expected
@@ -160,9 +162,9 @@ class LetsEncrypt {
        *   hostname: '_acme-challenge.testing.user1.starchart.com'
        * }
        */
-    }
 
-    return txtRecords?.includes(key) ?? false;
+      return false;
+    }
   };
 
   /**

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -1,5 +1,6 @@
 import { prisma } from '~/db.server';
 import logger from '~/lib/logger.server';
+import { buildUserBaseDomain } from '~/utils';
 
 import type { User as PrismaUser } from '@prisma/client';
 
@@ -7,25 +8,6 @@ export interface User extends PrismaUser {
   // the base domain to use for all DNS records created by this user
   // (e.g., jsmith.starchart.com with records using *.jsmith.starchart.com)
   baseDomain: string;
-}
-
-/**
- * Remove invalid/unwanted characters from a username. In the case
- * of faculty/admins, we will have a `.` in the username, which we
- * don't want to use as part of domain names.
- * @param username The user's username (e.g., `jsmith` or `john.smith`)
- */
-function cleanUsername(username: PrismaUser['username']) {
-  return username.replace(/\./g, '');
-}
-
-/**
- * Create the domain for a user, using their username
- * @param username The user's username (e.g., `jsmith` or `john.smith`)
- * @returns string jsmith -> jsmith.starchart.com
- */
-function buildUserBaseDomain(username: PrismaUser['username']) {
-  return `${cleanUsername(username)}.${process.env.ROOT_DOMAIN}`;
 }
 
 export async function getUserByUsername(username: PrismaUser['username']) {

--- a/app/queues/certificate/dns-waiter-worker.server.ts
+++ b/app/queues/certificate/dns-waiter-worker.server.ts
@@ -1,6 +1,12 @@
 import { Worker } from 'bullmq';
 import { redis } from '~/lib/redis.server';
 import logger from '~/lib/logger.server';
+import LetsEncrypt from '~/lib/lets-encrypt.server';
+import { getChildrenValuesOfQueueName } from '~/utils';
+import * as challengeModel from '~/models/challenge.server';
+import { orderCreatorQueueName } from './order-creator-worker.server';
+
+import type { OrderCreatorOutputData } from './order-creator-worker.server';
 
 export interface DnsWaiterData {
   rootDomain: string;
@@ -9,11 +15,67 @@ export interface DnsWaiterData {
 
 export const dnsWaiterQueueName = 'certificate-waitDns';
 
+/**
+ * This worker
+ * - Takes the certificate id from the child "order-creator-worker"
+ * - Reloads the challenges from DB
+ * - Verifies each challenge
+ *   - If all successful, completes this queue
+ *   - If any fails, it throws, so BullMQ will retry
+ */
+
 export const dnsWaiterWorker = new Worker<DnsWaiterData>(
   dnsWaiterQueueName,
   async (job) => {
     const { rootDomain } = job.data;
-    logger.info(`TODO wait on DNS for ${rootDomain}`);
+    const childrenValues = await getChildrenValuesOfQueueName<OrderCreatorOutputData>({
+      queueName: orderCreatorQueueName,
+      job,
+    });
+
+    // Get the order creator return value
+    const [orderCreatorRetval] = Object.values(childrenValues);
+
+    logger.info('Checking challenges in DNS', {
+      rootDomain,
+      certificateId: orderCreatorRetval.certificateId,
+    });
+
+    const challenges = await challengeModel.getChallengesByCertificateId(
+      orderCreatorRetval.certificateId
+    );
+
+    // Using a for .. of loop here instear of forEach to be able to await
+    for (const challenge of challenges) {
+      logger.debug('Checking challenge', {
+        rootDomain,
+        certificateId: orderCreatorRetval.certificateId,
+        domain: challenge.domain,
+        key: challenge.challengeKey,
+      });
+
+      console.log('foo');
+      const challengeResult = await LetsEncrypt.verifyChallenge({
+        domain: challenge.domain,
+        key: challenge.challengeKey,
+      });
+      console.log('bar');
+
+      if (!challengeResult) {
+        logger.debug('Challenge **not found** in DNS', {
+          rootDomain,
+          certificateId: orderCreatorRetval.certificateId,
+          domain: challenge.domain,
+          key: challenge.challengeKey,
+        });
+        throw new Error(`At least one challenge is failing on ${rootDomain}`);
+      }
+
+      logger.info('All challenges successfully verified in DNS', {
+        rootDomain,
+        certificateId: orderCreatorRetval.certificateId,
+      });
+    }
   },
   { connection: redis }
 );

--- a/app/queues/certificate/dns-waiter-worker.server.ts
+++ b/app/queues/certificate/dns-waiter-worker.server.ts
@@ -45,7 +45,7 @@ export const dnsWaiterWorker = new Worker<DnsWaiterData>(
       orderCreatorRetval.certificateId
     );
 
-    // Using a for .. of loop here instear of forEach to be able to await
+    // Using a for .. of loop here instead of forEach to be able to await
     for (const challenge of challenges) {
       logger.debug('Checking challenge', {
         rootDomain,

--- a/app/queues/certificate/dns-waiter-worker.server.ts
+++ b/app/queues/certificate/dns-waiter-worker.server.ts
@@ -54,12 +54,10 @@ export const dnsWaiterWorker = new Worker<DnsWaiterData>(
         key: challenge.challengeKey,
       });
 
-      console.log('foo');
       const challengeResult = await LetsEncrypt.verifyChallenge({
         domain: challenge.domain,
         key: challenge.challengeKey,
       });
-      console.log('bar');
 
       if (!challengeResult) {
         logger.debug('Challenge **not found** in DNS', {

--- a/app/queues/certificate/order-creator-worker.server.ts
+++ b/app/queues/certificate/order-creator-worker.server.ts
@@ -39,7 +39,7 @@ const handleChallenges = ({
      */
     await addDnsRequest({
       username,
-      type: 'A',
+      type: 'TXT',
       name: domain,
       value: challengeKey,
     });

--- a/app/queues/certificate/order-creator-worker.server.ts
+++ b/app/queues/certificate/order-creator-worker.server.ts
@@ -4,6 +4,7 @@ import logger from '~/lib/logger.server';
 import LetsEncrypt from '~/lib/lets-encrypt.server';
 import * as certificateModel from '~/models/certificate.server';
 import * as challengeModel from '~/models/challenge.server';
+import { addDnsRequest } from '~/queues/dns/dns-flow.server';
 
 import type { ChallengeBundle } from '~/lib/lets-encrypt.server';
 
@@ -14,14 +15,6 @@ export interface OrderCreatorData {
 
 export interface OrderCreatorOutputData {
   certificateId: number;
-  username: string;
-  rootDomain: string;
-  orderUrl: string;
-  challengeEntries: {
-    id: number;
-    domain: string;
-    challengeKey: string;
-  }[];
 }
 
 export const orderCreatorQueueName = 'certificate-createOrder';
@@ -29,13 +22,27 @@ export const orderCreatorQueueName = 'certificate-createOrder';
 /**
  * This async fn handles adding challenges to DB and DNS
  */
-const handleChallenges = (certificateId: number, bundles: ChallengeBundle[]) => {
+const handleChallenges = ({
+  username,
+  certificateId,
+  bundles,
+}: {
+  username: string;
+  certificateId: number;
+  bundles: ChallengeBundle[];
+}) => {
   const challengeInsertPromises = bundles.map(async ({ domain, value: challengeKey }) => {
     logger.info(`Adding challenge to DNS`, { domain, challengeKey });
 
     /**
-     * TODO actually add challenge to DNS
+     * add challenge to DNS
      */
+    await addDnsRequest({
+      username,
+      type: 'A',
+      name: domain,
+      value: challengeKey,
+    });
 
     return challengeModel.createChallenge({
       domain,
@@ -115,15 +122,8 @@ export const orderCreatorWorker = new Worker<OrderCreatorData, OrderCreatorOutpu
      * Add challenges to DB and DNS, get back id, domain, challengeKey, for each of them
      */
 
-    let challengeEntries;
     try {
-      challengeEntries = (await handleChallenges(certificateId, letsEncrypt.challengeBundles!)).map(
-        ({ id, domain, challengeKey }) => ({
-          id,
-          domain,
-          challengeKey,
-        })
-      );
+      await handleChallenges({ username, certificateId, bundles: letsEncrypt.challengeBundles! });
       logger.info('All challenge entries have been added');
     } catch (e) {
       // Log and rethrow the same error to keep message and stack
@@ -136,10 +136,6 @@ export const orderCreatorWorker = new Worker<OrderCreatorData, OrderCreatorOutpu
      */
     return {
       certificateId,
-      username,
-      rootDomain,
-      orderUrl: letsEncrypt.order!.url,
-      challengeEntries,
     } as OrderCreatorOutputData;
   },
   { connection: redis }

--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -29,7 +29,7 @@ export const action = async ({ request }: ActionArgs) => {
       // Because of the foreign key constraint, it needs to be an existing user
       await addCertRequest({
         username: 'starchartdev',
-        rootDomain: 'testing.starchartdev.starchart.com',
+        rootDomain: 'testing.user1.starchart.com',
       });
       return json({
         result: 'ok',

--- a/app/routes/dev.tsx
+++ b/app/routes/dev.tsx
@@ -28,8 +28,8 @@ export const action = async ({ request }: ActionArgs) => {
     case 'certificate-request':
       // Because of the foreign key constraint, it needs to be an existing user
       await addCertRequest({
-        username: 'starchartdev',
-        rootDomain: 'testing.user1.starchart.com',
+        username: user.username,
+        rootDomain: user.baseDomain,
       });
       return json({
         result: 'ok',
@@ -48,9 +48,9 @@ export const action = async ({ request }: ActionArgs) => {
     case 'dns-record-request':
       await addDnsRequest({
         type: 'A',
-        name: 'osd700-a1.user1.starchart.com',
+        name: `osd700-a1.${user.baseDomain}`,
         value: '192.168.0.1',
-        username: 'user1',
+        username: user.username,
       });
       return json({
         result: 'ok',

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -2,6 +2,7 @@ import { useMatches } from '@remix-run/react';
 import { useMemo } from 'react';
 
 import type { User } from '~/models/user.server';
+import type { Job } from 'bullmq';
 
 const DEFAULT_REDIRECT = '/';
 
@@ -62,4 +63,30 @@ export function useUser(): User {
     );
   }
   return maybeUser;
+}
+
+/**
+ * This async Fn takes a BullMQ job, and the queue name
+ * and returns children jobs that are of that queue name
+ * @param {string} jobName
+ * @param {Job} job
+ *
+ * @returns {Promise<Object>}
+ */
+
+export async function getChildrenValuesOfQueueName<CT>({
+  queueName,
+  job,
+}: {
+  queueName: string;
+  job: Job;
+}): Promise<{
+  [jobKey: string]: CT;
+}> {
+  const childrenValues = await job.getChildrenValues();
+  const filteredChildrenValues = Object.keys(childrenValues)
+    .filter((jobKey) => jobKey.includes(queueName))
+    .reduce((acc, jobKey) => ({ ...acc, [jobKey]: childrenValues[jobKey] }), {});
+
+  return filteredChildrenValues;
 }


### PR DESCRIPTION
- Alters Let's encrypt class to handle DNS error
- Alters DNS worker, enhances error logging
- Adds request to DNS worker to inject appropriate records
- Implements DNS propagation waiter worker
- Simplifies Cert order worker, simplifies response (no need for additional data)

Closes #169 