### PR TITLE
Use correct staging IDP metadata filename for CI docker build

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -355,7 +355,7 @@ jobs:
         with:
           context: .
           build-args: |
-            SAML_IDP_METADATA_PATH=config/staging-idp-metadata.xml
+            SAML_IDP_METADATA_PATH=./config/idp-metadata-staging.xml
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
I forgot to fix the filename I use for the Docker build arg of the staging IDP metadata.  Tested this locally:

```sh
docker build -t starchart --build-arg SAML_IDP_METADATA_PATH=./config/idp-metadata-staging.xml .

[+] Building 38.0s (20/20) FINISHED
 => [internal] load build definition from Dockerfile                                         0.0s
 => => transferring dockerfile: 32B                                                          0.0s
 => [internal] load .dockerignore                                                            0.0s
 => => transferring context: 35B                                                             0.0s
 => [internal] load metadata for docker.io/library/node:18-bullseye-slim@sha256:e2fbe082615  0.0s
 => CACHED [base 1/2] FROM docker.io/library/node:18-bullseye-slim@sha256:e2fbe082615911b18  0.0s
 => [internal] load build context                                                            0.1s
 => => transferring context: 176.03kB                                                        0.1s
 => [base 2/2] RUN apt-get update &&   apt-get install -y --no-install-recommends   curl=7.  3.6s
 => [build 1/4] WORKDIR /app                                                                 0.0s
 => [deps 2/3] COPY package*.json .npmrc ./                                                  0.0s
 => [deps 3/3] RUN npm ci --include=dev --ignore-scripts                                    20.6s
 => [build 2/4] COPY --from=deps /app/node_modules ./node_modules                            3.4s
 => [production-deps 3/4] COPY package*.json .npmrc ./                                       0.0s
 => [build 3/4] COPY . .                                                                     0.3s
 => [production-deps 4/4] RUN npm prune --omit=dev                                           2.9s
 => [build 4/4] RUN npx prisma generate   && npm run build                                   6.9s
 => [deploy 2/6] COPY --chown=node:node --from=production-deps /app/node_modules ./node_mod  1.4s
 => [deploy 3/6] COPY --chown=node:node --from=build /app/node_modules/.prisma ./node_modul  0.0s
 => [deploy 4/6] COPY --chown=node:node --from=build /app/build ./build                      0.0s
 => [deploy 5/6] COPY --chown=node:node --from=build /app/public ./public                    0.0s
 => [deploy 6/6] COPY --chown=node:node ./config/idp-metadata-staging.xml ./config/idp-meta  0.0s
 => exporting to image                                                                       0.8s
 => => exporting layers                                                                      0.8s
 => => writing image sha256:724d3a869580046255cc294a1c538a9013a532173bdc0b6917f3eab84914cdd  0.0s
 => => naming to docker.io/library/starchart                                                 0.0s
```