### PR TITLE
Add prisma Docker target + CI to setup db in staging/prod

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,7 +314,7 @@ jobs:
             # cache node modules using the same key as restore.
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
-  Docker-Build:
+  Starchart-Docker:
     # We'll only build and push when landing on main, not for PRs
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
@@ -326,9 +326,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -350,7 +347,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push Starchart Docker image
         uses: docker/build-push-action@v4
         with:
           context: .

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 legacy-peer-deps=true
+update-notifier=false

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -43,3 +43,15 @@ The following secrets must be added to the Docker engine using [Docker Swarm sec
 | `NOTIFICATIONS_USERNAME`               | The SMTP username to use for sending notifications                                                                                                                           |
 | `NOTIFICATIONS_PASSWORD`               | The SMTP password to use for sending notifications                                                                                                                           |
 | `DATABASE_URL`                         | The MySQL database connection string URL. NOTE: this is needed as an environment variable only when doing database setup commands, but read as a secret when running the app |
+
+## Running the App via Docker
+
+The app can be started via Docker. If it is the first time you are starting the app, or if there are database changes that need to be applied first, you can set `DATABASE_SETUP=1` in the environment to run Prisma and sync the schema and database:
+
+```sh
+# Run the app without doing anything to the database
+$ docker run ghcr.io/developingspace/starchart
+
+# OR, run the app, but sync the datbase first
+$ docker run -e DATABASE_SETUP=1 ghcr.io/developingspace/starchart
+```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -eo pipefail
+
+# Run the necessary commands to sync the Prisma schema
+# with the database. We pull the database URL out of
+# secrets, since Prisma requires it as an env var.
+database_setup() {
+  echo "Running database setup..."
+  DATABASE_URL=$(</run/secrets/DATABASE_URL)
+  export DATABASE_URL
+
+  npx prisma db push
+
+  # Clear the DATABASE_URL from the env. The app uses it via secrets
+  unset DATABASE_URL
+  echo "Database setup complete"
+}
+
+# See if we need to do database setup before starting.
+if [[ $DATABASE_SETUP == "1" ]]; then
+  # Run our database setup
+  database_setup
+fi
+
+# Run the app normally, switching to the node process as PID 1
+exec "$@"


### PR DESCRIPTION
Part of #291

In order to ship to staging/production, we need to be able to set up the database.  Doing so requires running Prisma with our schema from the staging/production VMs.  This creates a Docker build stage that can be optionally run in a stand-alone way to accomplish this.

Every time we push to `main`, CI will create both `startchart` and `starchart-prisma` images.  The latter is used to push the current schema to the database (there might be a better set of commands for us to run, let me know what you think).

We won't do this automatically, but I need this to exist so I can run it manually via Docker.

This change also does the following:

1. Updates the SHA of the node 18 image we use (they shipped a security update recently)
2. Adds a `db:setup` npm script that does everything except seeds the db
3. Removes QEMU from the Docker jobs, since we aren't cross-compiling anymore

This doesn't need to get looked at until next week as part of 0.6.