### PR TITLE
Use secrets for DATABASE_URL in prod, update deploy docs

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -34,11 +34,12 @@ The following configuration values must be set via environment variables.
 
 The following secrets must be added to the Docker engine using [Docker Swarm secrets](https://docs.docker.com/engine/swarm/secrets/).
 
-| Secret Name                            | Description                                                      |
-| -------------------------------------- | ---------------------------------------------------------------- |
-| `AWS_ACCESS_KEY_ID`                    | The AWS Account Access Key ID for use with Route 53              |
-| `AWS_SECRET_ACCESS_KEY`                | The AWS Account Secret Access Key for use with Route 53          |
-| `LETS_ENCRYPT_ACCOUNT_PRIVATE_KEY_PEM` | The RSA Private Key for the Let's Encrypt account, in PEM format |
-| `SESSION_SECRET`                       | The long, random string to use for keying sessions               |
-| `NOTIFICATIONS_USERNAME`               | The SMTP username to use for sending notifications               |
-| `NOTIFICATIONS_PASSWORD`               | The SMTP password to use for sending notifications               |
+| Secret Name                            | Description                                                                                                                                                                  |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `AWS_ACCESS_KEY_ID`                    | The AWS Account Access Key ID for use with Route 53                                                                                                                          |
+| `AWS_SECRET_ACCESS_KEY`                | The AWS Account Secret Access Key for use with Route 53                                                                                                                      |
+| `LETS_ENCRYPT_ACCOUNT_PRIVATE_KEY_PEM` | The RSA Private Key for the Let's Encrypt account, in PEM format                                                                                                             |
+| `SESSION_SECRET`                       | The long, random string to use for keying sessions                                                                                                                           |
+| `NOTIFICATIONS_USERNAME`               | The SMTP username to use for sending notifications                                                                                                                           |
+| `NOTIFICATIONS_PASSWORD`               | The SMTP password to use for sending notifications                                                                                                                           |
+| `DATABASE_URL`                         | The MySQL database connection string URL. NOTE: this is needed as an environment variable only when doing database setup commands, but read as a secret when running the app |

--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
+
 import logger from '~/lib/logger.server';
+import secrets from './lib/secrets.server';
 
 let prisma: PrismaClient;
 
@@ -21,9 +23,14 @@ if (process.env.NODE_ENV === 'production') {
 }
 
 function getClient() {
-  const { DATABASE_URL } = process.env;
+  const DATABASE_URL =
+    process.env.NODE_ENV === 'production'
+      ? secrets.DATABASE_URL
+      : // Allow using env or secrets in dev/testing only
+        secrets.DATABASE_URL || process.env.DATABASE_URL;
+
   if (typeof DATABASE_URL !== 'string') {
-    throw new Error('DATABASE_URL env var not set');
+    throw new Error('DATABASE_URL secret not set');
   }
 
   const databaseUrl = new URL(DATABASE_URL);


### PR DESCRIPTION
Continuing to prepare for #43, and I notice that the `DATABASE_URL` wasn't being read from Docker secrets.  I've updated it so that it uses secrets in production, but we still allow env overriding in development and testing.  By default, though, it will now use what's in `dev-secrets/DATABASE_URL` as the value.

I've also added this to the `DEPLOY` doc.