### PR TITLE
Retry playwright tests at least once

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,8 +19,12 @@ const config: PlaywrightTestConfig = {
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 2 : 0,
+  /**
+   * Retry on CI twice
+   * Retry in development once - this generated a video on the first retry of a failed test,
+   * allowing easier debugging without pushing to a branch or modifying this manually
+   */
+  retries: process.env.CI ? 2 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */


### PR DESCRIPTION
 Videos and traces are configured to be generated on the first retry. So, changing the number of retries outside of the `CI` environment to 1 would allow for easier debugging when running tests locally