### PR TITLE
Add Worker/Queue to process expired DNS records

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,9 @@ SMTP_PORT=1025
 APP_URL=http://host.docker.internal:8080
 # The SimpleSAML IDP's XML metadata
 SAML_IDP_METADATA_PATH=config/idp-metadata-dev.xml
+
+# Background jobs
+# 24 * 60 * 60 * 1000 = 604800000 (24 hours)
+EXPIRATION_REPEAT_FREQUENCY_MS=86400000
+# 7 * 24 * 60 * 60 * 1000 = 604800000 (7 days)
+JOB_REMOVAL_FREQUENCY_MS=604800000

--- a/app/models/record.server.ts
+++ b/app/models/record.server.ts
@@ -112,3 +112,16 @@ export function renewDnsRecordById(id: Record['id']) {
     },
   });
 }
+
+export function getExpiredRecords() {
+  return prisma.record.findMany({
+    where: {
+      expiresAt: {
+        lt: new Date(),
+      },
+    },
+    include: {
+      user: true,
+    },
+  });
+}

--- a/app/queues/common/expiration-request.server.ts
+++ b/app/queues/common/expiration-request.server.ts
@@ -1,0 +1,60 @@
+import { Worker, Queue, UnrecoverableError } from 'bullmq';
+
+import { redis } from '~/lib/redis.server';
+import logger from '~/lib/logger.server';
+
+import { getExpiredRecords } from '~/models/record.server';
+import { addNotification } from '../notifications/notifications.server';
+import { deleteDnsRequest } from '../dns/delete-record-flow.server';
+
+const { EXPIRATION_REPEAT_FREQUENCY_MS, JOB_REMOVAL_FREQUENCY_MS } = process.env;
+
+// constant  for removing job on completion/failure (in milliseconds)
+const JOB_REMOVAL_INTERVAL_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+declare global {
+  var __expiration_request_init__: boolean;
+}
+// queue name
+const expirationRequestQueueName = 'expiration-request';
+
+// queue initialization
+const expirationRequestQueue = new Queue(expirationRequestQueueName, {
+  connection: redis,
+});
+
+export function addExpirationRequest() {
+  return expirationRequestQueue.add(expirationRequestQueueName, {
+    repeat: { every: Number(EXPIRATION_REPEAT_FREQUENCY_MS) || 24 * 60 * 60 * 1000 },
+    removeOnComplete: { age: Number(JOB_REMOVAL_FREQUENCY_MS) || JOB_REMOVAL_INTERVAL_MS },
+    removeOnFail: { age: Number(JOB_REMOVAL_FREQUENCY_MS) || JOB_REMOVAL_INTERVAL_MS },
+  });
+}
+
+// worker definition
+const expirationRequestWorker = new Worker(
+  expirationRequestQueueName,
+  async (job) => {
+    try {
+      logger.info('process DNS record expiration');
+      let dnsRecords = await getExpiredRecords();
+      Promise.all(
+        dnsRecords.map(async ({ id, username, type, subdomain, value, user }) => {
+          // delete records from Route53 and DB
+          await deleteDnsRequest({ id, username, type, subdomain, value });
+          // add notification jobs (assuming deletion went successfully)
+          await addNotification({
+            emailAddress: user.email,
+            subject: 'DNS record expiration subject',
+            message: 'DNS record expiration message',
+          });
+        })
+      );
+    } catch (err) {
+      throw new UnrecoverableError(`Unable to process DNS record expiration: ${err}`);
+    }
+    logger.info('TODO: process certificate expiration');
+  },
+  { connection: redis }
+);
+
+process.on('SIGINT', () => expirationRequestWorker.close());

--- a/app/queues/notifications/expiration-notification.server.ts
+++ b/app/queues/notifications/expiration-notification.server.ts
@@ -14,12 +14,11 @@ import type { NotificationData } from './notifications.server';
 declare global {
   var __expiration_init__: boolean;
 }
-
-enum RecordType {
+export enum RecordType {
   Certificate = 'certificate',
   DnsRecord = 'record',
 }
-interface ExpirationStatusPayload {
+export interface ExpirationStatusPayload {
   type: RecordType;
 }
 // constant for notification frequency in days


### PR DESCRIPTION
## Description
Resolves #112 by adding Worker/Queue to do the following:
1. Query the database for expired DNS records
2. If Step 1. yields any results, delete DNS Records from Route53 and delete the record from DB (via `deleteDnsRequest`)
3. Send Notification 


Step 2 is not working as intended. Invoking `deleteDnsRequest` in the front-end/back-end fails with the following warning: 
```bash
warn: Invalid request: Expected exactly one of [AliasTarget, all of [TTL, and ResourceRecords], or TrafficPolicyInstanceId], but found none in Change with [Action=DELETE, Name=osd700-a1.user1.starchart.com, Type=A, SetIdentifier=null]
```
Possibly linked to the missing [TTL](https://github.com/boto/boto3/issues/3161) value.