### PR TITLE
Test: Certificate, Header

### DIFF
--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -58,7 +58,7 @@ export default function CertificateDisplay({ title, description, value }: Certif
             onClick={() => onCopy()}
           />
         </Tooltip>
-        <Tooltip label={`${title} is Downloaded`}>
+        <Tooltip label={`Download ${title}`}>
           <IconButton
             backgroundColor="transparent"
             color="black"

--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -53,7 +53,7 @@ export default function CertificateDisplay({ title, description, value }: Certif
               background: 'whitesmoke',
               color: 'teal.500',
             }}
-            aria-label="Copy to Clipboard"
+            aria-label={`Copy ${title}`}
             icon={<CopyIcon fontSize="md" />}
             onClick={() => onCopy()}
           />
@@ -67,7 +67,7 @@ export default function CertificateDisplay({ title, description, value }: Certif
               background: 'brand.500',
               color: 'white',
             }}
-            aria-label="Download"
+            aria-label={`Download ${title}`}
             icon={
               <DownloadIcon
                 fontSize="md"

--- a/app/components/header.tsx
+++ b/app/components/header.tsx
@@ -57,6 +57,7 @@ export default function Header() {
         <Flex width="100%">
           <Menu>
             <MenuButton
+              className="header-hamburger"
               as={Button}
               rightIcon={<HamburgerIcon />}
               size="auto"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,12 +34,12 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: `http://localhost:${process.env.PORT || 8080}`,
+    baseURL: 'http://localhost:8080',
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'retain-on-failure',
+    trace: 'on-first-retry',
     /* Record video on first retry */
-    video: 'retain-on-failure',
+    video: 'on-first-retry',
   },
 
   /* Configure projects for major browsers */

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,12 +34,12 @@ const config: PlaywrightTestConfig = {
     /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
     actionTimeout: 0,
     /* Base URL to use in actions like `await page.goto('/')`. */
-    baseURL: `http://localhost:${process.env.PORT}`,
+    baseURL: `http://localhost:${process.env.PORT || 8080}`,
 
     /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
-    trace: 'on-first-retry',
+    trace: 'retain-on-failure',
     /* Record video on first retry */
-    video: 'on-first-retry',
+    video: 'retain-on-failure',
   },
 
   /* Configure projects for major browsers */
@@ -58,6 +58,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Chrome'],
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.mobile\.spec\.ts/,
     },
 
     {
@@ -66,6 +67,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Firefox'],
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.mobile\.spec\.ts/,
     },
 
     {
@@ -74,6 +76,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Desktop Safari'],
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.mobile\.spec\.ts/,
     },
 
     /* Test against mobile viewports. */
@@ -83,6 +86,7 @@ const config: PlaywrightTestConfig = {
         ...devices['Pixel 5'],
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.desktop\.spec\.ts/,
     },
     /**
      * We override the isMobile for Mobile Safari to false to make it work in CI
@@ -100,6 +104,7 @@ const config: PlaywrightTestConfig = {
         defaultBrowserType: devices['iPhone 12'].defaultBrowserType,
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.desktop\.spec\.ts/,
     },
 
     /* Test against branded browsers. */
@@ -109,6 +114,7 @@ const config: PlaywrightTestConfig = {
         channel: 'msedge',
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.mobile\.spec\.ts/,
     },
     {
       name: 'Google Chrome',
@@ -116,6 +122,7 @@ const config: PlaywrightTestConfig = {
         channel: 'chrome',
       },
       dependencies: ['setup'],
+      testIgnore: /.*\.mobile\.spec\.ts/,
     },
   ],
 

--- a/test/e2e/auth.setup.ts
+++ b/test/e2e/auth.setup.ts
@@ -8,7 +8,7 @@ setup('authenticate as user', async ({ page }) => {
   await page.getByLabel('Username').fill('user1');
   await page.getByLabel('Password').fill('user1pass');
   await page.getByRole('button', { name: 'Login' }).click();
-  await page.waitForURL('http://localhost:8080');
+  await page.waitForURL('/');
 
   await page.context().storageState({ path: userFile });
 });

--- a/test/e2e/certificate.spec.ts
+++ b/test/e2e/certificate.spec.ts
@@ -24,9 +24,7 @@ test.describe('Certificate Page', () => {
       })
       .nth(1);
 
-    await expect(loadingPageText).toContainText(
-      'We have received your request, and will notify you when your certificate is read'
-    );
+    await loadingPageText.waitFor();
 
     //Copy Key Toast Text
     await page.getByRole('button', { name: 'Copy Public Key' }).click();
@@ -35,8 +33,8 @@ test.describe('Certificate Page', () => {
     const publicCopyToastText = page.getByText('Public Key was copied to the clipboard');
     const privateCopyToastText = page.getByText('Private Key was copied to the clipboard');
 
-    await expect(publicCopyToastText).toContainText('Public Key was copied to the clipboard');
-    await expect(privateCopyToastText).toContainText('Private Key was copied to the clipboard');
+    await publicCopyToastText.waitFor();
+    await privateCopyToastText.waitFor();
 
     //Download Key Toast Text
     await page.getByRole('button', { name: 'Download Public Key' }).click();
@@ -45,8 +43,8 @@ test.describe('Certificate Page', () => {
     const publicDownloadToastText = page.getByText('Public Key is Downloaded');
     const privateDownloadToastText = page.getByText('Private Key is Downloaded');
 
-    await expect(publicDownloadToastText).toContainText('Public Key is Downloaded');
-    await expect(privateDownloadToastText).toContainText('Private Key is Downloaded');
+    await publicDownloadToastText.waitFor();
+    await privateDownloadToastText.waitFor();
 
     //Text Titles
     const publicKey = page.getByRole('heading', { name: 'Public Key' });

--- a/test/e2e/certificate.spec.ts
+++ b/test/e2e/certificate.spec.ts
@@ -14,21 +14,41 @@ test.describe('Certificate Page', () => {
 
     await expect(domainName).toContainText('user1.starchart.com');
     await expect(titleHeader).toContainText('Certificate');
+
     await page.getByRole('button', { name: 'Request a Certificate' }).click();
 
-    page
+    const loadingPageText = page
       .locator('div')
       .filter({
         hasText: 'We have received your request, and will notify you when your certificate is read',
       })
       .nth(1);
 
+    await expect(loadingPageText).toContainText(
+      'We have received your request, and will notify you when your certificate is read'
+    );
+
+    //Copy Key Toast Text
     await page.getByRole('button', { name: 'Copy Public Key' }).click();
     await page.getByRole('button', { name: 'Copy Private Key' }).click();
 
+    const publicCopyToastText = page.getByText('Public Key was copied to the clipboard');
+    const privateCopyToastText = page.getByText('Private Key was copied to the clipboard');
+
+    await expect(publicCopyToastText).toContainText('Public Key was copied to the clipboard');
+    await expect(privateCopyToastText).toContainText('Private Key was copied to the clipboard');
+
+    //Download Key Toast Text
     await page.getByRole('button', { name: 'Download Public Key' }).click();
     await page.getByRole('button', { name: 'Download Private Key' }).click();
 
+    const publicDownloadToastText = page.getByText('Public Key is Downloaded');
+    const privateDownloadToastText = page.getByText('Private Key is Downloaded');
+
+    await expect(publicDownloadToastText).toContainText('Public Key is Downloaded');
+    await expect(privateDownloadToastText).toContainText('Private Key is Downloaded');
+
+    //Text Titles
     const publicKey = page.getByRole('heading', { name: 'Public Key' });
     const privateKey = page.getByRole('heading', { name: 'Private Key' });
 

--- a/test/e2e/certificate.spec.ts
+++ b/test/e2e/certificate.spec.ts
@@ -15,6 +15,7 @@ test.describe('Certificate Page', () => {
     await expect(domainName).toContainText('user1.starchart.com');
     await expect(titleHeader).toContainText('Certificate');
     await page.getByRole('button', { name: 'Request a Certificate' }).click();
+
     page
       .locator('div')
       .filter({

--- a/test/e2e/certificate.spec.ts
+++ b/test/e2e/certificate.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { loggedInAsUser } from './utils';
+
+test.describe('Certificate Page', () => {
+  loggedInAsUser();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/certificate');
+  });
+
+  test('Request a Certificate', async ({ page }) => {
+    const titleHeader = page.getByRole('heading', { name: 'Certificate' });
+    const domainName = page.getByText('user1.starchart.com');
+
+    await expect(domainName).toContainText('user1.starchart.com');
+    await expect(titleHeader).toContainText('Certificate');
+    await page.getByRole('button', { name: 'Request a Certificate' }).click();
+    page
+      .locator('div')
+      .filter({
+        hasText: 'We have received your request, and will notify you when your certificate is read',
+      })
+      .nth(1);
+
+    await page.getByRole('button', { name: 'Copy Public Key' }).click();
+    await page.getByRole('button', { name: 'Copy Private Key' }).click();
+
+    await page.getByRole('button', { name: 'Download Public Key' }).click();
+    await page.getByRole('button', { name: 'Download Private Key' }).click();
+
+    const publicKey = page.getByRole('heading', { name: 'Public Key' });
+    const privateKey = page.getByRole('heading', { name: 'Private Key' });
+
+    await expect(publicKey).toContainText('Public Key');
+    await expect(privateKey).toContainText('Private Key');
+  });
+});

--- a/test/e2e/header/header.desktop.spec.ts
+++ b/test/e2e/header/header.desktop.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+import { loggedInAsUser } from '../utils';
+
+test.describe('navigate to links', () => {
+  loggedInAsUser();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('navigate to certificate and domain (desktop)', async ({ page }) => {
+    await page.getByRole('link', { name: 'Certificate', exact: true }).click();
+    await expect(page).toHaveURL('/certificate');
+
+    await page.getByRole('link', { name: 'Domains', exact: true }).click();
+    await expect(page).toHaveURL('/domains');
+  });
+});

--- a/test/e2e/header/header.mobile.spec.ts
+++ b/test/e2e/header/header.mobile.spec.ts
@@ -1,0 +1,20 @@
+import { test, expect } from '@playwright/test';
+import { loggedInAsUser } from '../utils';
+
+test.describe('navigate to links through mobile', () => {
+  loggedInAsUser();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('navigate to certificate and domain (mobile)', async ({ page }) => {
+    await page.click('.header-hamburger');
+    await page.getByRole('link', { name: 'Certificate', exact: true }).click();
+    await expect(page).toHaveURL('/certificate');
+
+    await page.click('.header-hamburger');
+    await page.getByRole('link', { name: 'Domains', exact: true }).click();
+    await expect(page).toHaveURL('/domains');
+  });
+});

--- a/test/e2e/header/header.spec.ts
+++ b/test/e2e/header/header.spec.ts
@@ -1,0 +1,16 @@
+import { test, expect } from '@playwright/test';
+import { loggedInAsUser } from '../utils';
+
+test.describe('sign out of the account', () => {
+  loggedInAsUser();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+  });
+
+  test('sign out', async ({ page }) => {
+    await page.getByRole('banner').getByRole('button').click();
+    await page.getByRole('menuitem', { name: 'Sign Out' }).click();
+    await expect(page).toHaveURL('/login?redirectTo=%2F');
+  });
+});

--- a/test/e2e/landing-page.spec.ts
+++ b/test/e2e/landing-page.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { loggedInAsUser } from './utils';
 
-test.describe('landing page link', () => {
+test.describe('Landing Page', () => {
   loggedInAsUser();
 
   test.beforeEach(async ({ page }) => {
@@ -14,12 +14,13 @@ test.describe('landing page link', () => {
     await expect(certCard).toContainText('Certificate');
   });
 
-  test('Manage DNS Records Link Button', async ({ page }) => {
+  test('Manage DNS Records Button', async ({ page }) => {
     await page.getByRole('link', { name: 'Manage DNS Records' }).click();
+
     await expect(page).toHaveURL('/domains');
   });
 
-  test('Manage DNS Records Instruction Link', async ({ page }) => {
+  test('DNS Records Instructions Link', async ({ page }) => {
     await page
       .getByRole('paragraph')
       .filter({
@@ -31,12 +32,13 @@ test.describe('landing page link', () => {
     await expect(page).toHaveURL('/domains/instructions');
   });
 
-  test('Manage Certificate Link Button', async ({ page }) => {
+  test('Manage Certificate Button', async ({ page }) => {
     await page.getByRole('link', { name: 'Manage Certificate' }).click();
+
     await expect(page).toHaveURL('/certificate');
   });
 
-  test('Manage Certificate Instruction Link', async ({ page }) => {
+  test('Certificate Instructions Link', async ({ page }) => {
     await page
       .getByRole('paragraph')
       .filter({
@@ -45,6 +47,7 @@ test.describe('landing page link', () => {
       })
       .getByRole('link', { name: 'to learn more, see these instructions...' })
       .click();
+
     await expect(page).toHaveURL('/certificate/instructions');
   });
 });

--- a/test/e2e/landing-page.spec.ts
+++ b/test/e2e/landing-page.spec.ts
@@ -6,7 +6,9 @@ test.describe('Landing Page', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
+  });
 
+  test('Contains DNS Record and Certificate cards', async ({ page }) => {
     const dnsCard = page.getByRole('heading', { name: 'DNS Records' });
     const certCard = page.getByRole('heading', { name: 'Certificate' });
 

--- a/test/e2e/landing-page.spec.ts
+++ b/test/e2e/landing-page.spec.ts
@@ -1,0 +1,50 @@
+import { test, expect } from '@playwright/test';
+import { loggedInAsUser } from './utils';
+
+test.describe('landing page link', () => {
+  loggedInAsUser();
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+
+    const dnsCard = page.getByRole('heading', { name: 'DNS Records' });
+    const certCard = page.getByRole('heading', { name: 'Certificate' });
+
+    await expect(dnsCard).toContainText('DNS Records');
+    await expect(certCard).toContainText('Certificate');
+  });
+
+  test('Manage DNS Records Link Button', async ({ page }) => {
+    await page.getByRole('link', { name: 'Manage DNS Records' }).click();
+    await expect(page).toHaveURL('/domains');
+  });
+
+  test('Manage DNS Records Instruction Link', async ({ page }) => {
+    await page
+      .getByRole('paragraph')
+      .filter({
+        hasText: 'DNS Record: Lorem Ipsum is simply dummy text of the printing and typesetting ind',
+      })
+      .getByRole('link', { name: 'to learn more, see these instructions...' })
+      .click();
+
+    await expect(page).toHaveURL('/domains/instructions');
+  });
+
+  test('Manage Certificate Link Button', async ({ page }) => {
+    await page.getByRole('link', { name: 'Manage Certificate' }).click();
+    await expect(page).toHaveURL('/certificate');
+  });
+
+  test('Manage Certificate Instruction Link', async ({ page }) => {
+    await page
+      .getByRole('paragraph')
+      .filter({
+        hasText:
+          'Certificate: Lorem Ipsum is simply dummy text of the printing and typesetting ind',
+      })
+      .getByRole('link', { name: 'to learn more, see these instructions...' })
+      .click();
+    await expect(page).toHaveURL('/certificate/instructions');
+  });
+});

--- a/test/e2e/login.spec.ts
+++ b/test/e2e/login.spec.ts
@@ -1,29 +1,33 @@
 import { test, expect } from '@playwright/test';
 
-test('Login with User 1', async ({ page }) => {
-  await page.goto('/login?redirectTo=%2F');
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await page.getByLabel('Username').fill('user1');
-  await page.getByLabel('Password').fill('user1pass');
-  await page.getByRole('button', { name: 'Login' }).click();
-  await page.waitForURL('http://localhost:8080');
-  const locator = page.locator('#header-user');
-  const starchartHeading = page.getByRole('heading', { name: 'My.Custom.Domain' });
-  await expect(locator).toContainText('user1');
-  await expect(starchartHeading).toContainText('My.Custom.Domain');
-});
+test.describe('Login with user', () => {
+  test('Login with User 1', async ({ page }) => {
+    await page.goto('/login?redirectTo=%2F');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByLabel('Username').fill('user1');
+    await page.getByLabel('Password').fill('user1pass');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL('http://localhost:8080');
 
-test('Login with User 1 dev redirect', async ({ page }) => {
-  await page.goto('/login?redirectTo=%2Fdomains');
-  await page.getByRole('button', { name: 'Sign In' }).click();
-  await page.getByLabel('Username').fill('user1');
-  await page.getByLabel('Password').fill('user1pass');
-  await page.getByRole('button', { name: 'Login' }).click();
-  await page.waitForURL('http://localhost:8080/domains');
-  const locator1 = page.locator('#header-user');
-  const userInNav = page.getByRole('heading', { name: 'My.Custom.Domain' });
-  const domainHeading = page.getByRole('heading', { name: 'Domains' });
-  await expect(locator1).toContainText('user1');
-  await expect(userInNav).toContainText('My.Custom.Domain');
-  await expect(domainHeading).toContainText('Domains');
+    const locator = page.locator('#header-user');
+    const starchartHeading = page.getByRole('heading', { name: 'My.Custom.Domain' });
+
+    await expect(locator).toContainText('user1');
+    await expect(starchartHeading).toContainText('My.Custom.Domain');
+  });
+
+  test('Login with User 1 dev redirect', async ({ page }) => {
+    await page.goto('/login?redirectTo=%2Fdomains');
+    await page.getByRole('button', { name: 'Sign In' }).click();
+    await page.getByLabel('Username').fill('user1');
+    await page.getByLabel('Password').fill('user1pass');
+    await page.getByRole('button', { name: 'Login' }).click();
+    await page.waitForURL('/domains');
+    const locator1 = page.locator('#header-user');
+    const userInNav = page.getByRole('heading', { name: 'My.Custom.Domain' });
+    const domainHeading = page.getByRole('heading', { name: 'Domains' });
+    await expect(locator1).toContainText('user1');
+    await expect(userInNav).toContainText('My.Custom.Domain');
+    await expect(domainHeading).toContainText('Domains');
+  });
 });

--- a/test/e2e/login.spec.ts
+++ b/test/e2e/login.spec.ts
@@ -22,9 +22,11 @@ test('Login with User 1 dev redirect', async ({ page }) => {
   await page.getByLabel('Password').fill('user1pass');
   await page.getByRole('button', { name: 'Login' }).click();
   await page.waitForURL('/domains');
+
   const locator1 = page.locator('#header-user');
   const userInNav = page.getByRole('heading', { name: 'My.Custom.Domain' });
   const domainHeading = page.getByRole('heading', { name: 'Domains' });
+
   await expect(locator1).toContainText('user1');
   await expect(userInNav).toContainText('My.Custom.Domain');
   await expect(domainHeading).toContainText('Domains');

--- a/test/e2e/login.spec.ts
+++ b/test/e2e/login.spec.ts
@@ -1,33 +1,31 @@
 import { test, expect } from '@playwright/test';
 
-test.describe('Login with user', () => {
-  test('Login with User 1', async ({ page }) => {
-    await page.goto('/login?redirectTo=%2F');
-    await page.getByRole('button', { name: 'Sign In' }).click();
-    await page.getByLabel('Username').fill('user1');
-    await page.getByLabel('Password').fill('user1pass');
-    await page.getByRole('button', { name: 'Login' }).click();
-    await page.waitForURL('http://localhost:8080');
+test('Login with User 1', async ({ page }) => {
+  await page.goto('/login?redirectTo=%2F');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByLabel('Username').fill('user1');
+  await page.getByLabel('Password').fill('user1pass');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await page.waitForURL('/');
 
-    const locator = page.locator('#header-user');
-    const starchartHeading = page.getByRole('heading', { name: 'My.Custom.Domain' });
+  const locator = page.locator('#header-user');
+  const starchartHeading = page.getByRole('heading', { name: 'My.Custom.Domain' });
 
-    await expect(locator).toContainText('user1');
-    await expect(starchartHeading).toContainText('My.Custom.Domain');
-  });
+  await expect(locator).toContainText('user1');
+  await expect(starchartHeading).toContainText('My.Custom.Domain');
+});
 
-  test('Login with User 1 dev redirect', async ({ page }) => {
-    await page.goto('/login?redirectTo=%2Fdomains');
-    await page.getByRole('button', { name: 'Sign In' }).click();
-    await page.getByLabel('Username').fill('user1');
-    await page.getByLabel('Password').fill('user1pass');
-    await page.getByRole('button', { name: 'Login' }).click();
-    await page.waitForURL('/domains');
-    const locator1 = page.locator('#header-user');
-    const userInNav = page.getByRole('heading', { name: 'My.Custom.Domain' });
-    const domainHeading = page.getByRole('heading', { name: 'Domains' });
-    await expect(locator1).toContainText('user1');
-    await expect(userInNav).toContainText('My.Custom.Domain');
-    await expect(domainHeading).toContainText('Domains');
-  });
+test('Login with User 1 dev redirect', async ({ page }) => {
+  await page.goto('/login?redirectTo=%2Fdomains');
+  await page.getByRole('button', { name: 'Sign In' }).click();
+  await page.getByLabel('Username').fill('user1');
+  await page.getByLabel('Password').fill('user1pass');
+  await page.getByRole('button', { name: 'Login' }).click();
+  await page.waitForURL('/domains');
+  const locator1 = page.locator('#header-user');
+  const userInNav = page.getByRole('heading', { name: 'My.Custom.Domain' });
+  const domainHeading = page.getByRole('heading', { name: 'Domains' });
+  await expect(locator1).toContainText('user1');
+  await expect(userInNav).toContainText('My.Custom.Domain');
+  await expect(domainHeading).toContainText('Domains');
 });

--- a/test/e2e/new-dns-record.spec.ts
+++ b/test/e2e/new-dns-record.spec.ts
@@ -12,8 +12,11 @@ test.describe('not authenticated', () => {
 test.describe('authenticated as user', () => {
   loggedInAsUser();
 
-  test('redirects to edit dns record page when required fields are filled', async ({ page }) => {
+  test.beforeEach(async ({ page }) => {
     await page.goto('/domains/new');
+  });
+
+  test('redirects to edit dns record page when required fields are filled', async ({ page }) => {
     await page.getByLabel('Record Name*').fill('test');
     await page.getByRole('combobox', { name: 'Type' }).selectOption('A');
     await page.getByLabel('Value*').fill('test');
@@ -22,7 +25,6 @@ test.describe('authenticated as user', () => {
   });
 
   test('redirects to edit dns record page when all fields are filled', async ({ page }) => {
-    await page.goto('/domains/new');
     await page.getByLabel('Record Name*').fill('test');
     await page.getByRole('combobox', { name: 'Type' }).selectOption('A');
     await page.getByLabel('Value*').fill('test');
@@ -34,8 +36,7 @@ test.describe('authenticated as user', () => {
   });
 
   test('does not create dns record if required fields are empty', async ({ page }) => {
-    await page.goto('/domains/new');
     await page.getByRole('button', { name: 'Create' }).click();
-    await expect(page).toHaveURL(/.*domains\/new/);
+    await expect(page).toHaveURL('/domains/new');
   });
 });


### PR DESCRIPTION
Fixes: #251, Fixes: #173 

This week, I'm creating a playwright test for the front end which includes, header, landing page and certificate

<details>

<summary>The certificate will cycle through 3 pages, and check for values that are specific for those pages</summary>

- Request Page
  - Check if user is currently on the `/certificate` route
  - Check for user domain name through text
  - Expect that the title heading is `Certificate`
- Loading Page
  - Check for the loading page to contain text 
- Key Page
  - Click download/clipboard buttons for private and public key
  - Catch toast pop up through heading

</details>

<details>
<summary>The header contains a hamburger state that is only visible in mobile, thus creating a new file `.mobile` to account for such instances</summary>

- Signout Button
  - Expect to redirect to `/login` route when clicked
- Card Links
  - Mobile
    - Click Hamburger Menu
    - Receive links to certificate and domain pages
    - Expect URL to either be `/domain` or `/certificate`
  - Desktop
    - Click either domain and certificate links
    - Expect URL to either be `/domain` or `/certificate`

</details>

<details>
<summary>On the landing page test we first check before starting if heading "DNS Records" and "Certificate" can be located in the `/` route</summary>

- Card
  - Button 
    - Find a button named "Manage DNS Records" or "Certificate"
    - Expect `/domains` or `/certificate` URL
  - Instruction Link
    - Look for a paragraph, and check if the paragraph contains a text: **to learn more, see these instructions...**
    - Expected URL when clicked `/domains/instructions` `/certificate/instructions`

</details>

We are also adding a `testIgnore` under `playwright.config.ts` to accommodate for instances where values are showing/hiding under different devices