### PR TITLE
Add deactivated flag to users

### DIFF
--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -47,6 +47,17 @@ export async function createUser(
   });
 }
 
+export async function deactivateUserByUsername(username: PrismaUser['username']) {
+  return prisma.user.update({
+    where: { username },
+    data: { deactivated: true },
+  });
+}
+
+export async function deleteUserByUsername(username: PrismaUser['username']) {
+  return prisma.user.delete({ where: { username } });
+}
+
 export async function isStudent(username: PrismaUser['username']) {
   const { group } = await prisma.user.findUniqueOrThrow({ where: { username } });
   // The group will have -dev in it on staging but not on prod

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -79,7 +79,7 @@ export async function isAdmin(username: PrismaUser['username']) {
 export async function isDeactivated(username: PrismaUser['username']) {
   const user = await prisma.user.findUnique({ where: { username } });
   if (!user) {
-    return true;
+    return undefined;
   }
 
   return user.deactivated;

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -64,3 +64,12 @@ export async function isAdmin(username: PrismaUser['username']) {
   // The group will have -dev in it on staging but not on prod
   return /mycustomdomain(-dev)?-admins/.test(group);
 }
+
+export async function isDeactivated(username: PrismaUser['username']) {
+  const user = await prisma.user.findUnique({ where: { username } });
+  if (!user) {
+    return true;
+  }
+
+  return user.deactivated;
+}

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -56,7 +56,7 @@ model Challenge {
   domain        String      @db.VarChar(255)
   challengeKey  String      @db.VarChar(255)
   certificateId Int
-  certificate   Certificate @relation(fields: [certificateId], references: [id])
+  certificate   Certificate @relation(fields: [certificateId], references: [id], onDelete: Cascade)
 }
 
 enum RecordType {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,8 +12,9 @@ model User {
   displayName String
   email       String        @unique
   group       String
-  createdAt   DateTime       @default(now())
-  updatedAt   DateTime       @updatedAt
+  createdAt   DateTime      @default(now())
+  updatedAt   DateTime      @updatedAt
+  deactivated Boolean       @default(false)
   record      Record[]
   certificate Certificate[]
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -33,7 +33,7 @@ model Record {
   expiresAt    DateTime
   status       RecordStatus
   lastNotified DateTime?
-  user         User         @relation(fields: [username], references: [username])
+  user         User         @relation(fields: [username], references: [username], onDelete: Cascade)
 }
 
 model Certificate {
@@ -47,7 +47,7 @@ model Certificate {
   validTo      DateTime?
   lastNotified DateTime?
   status       CertificateStatus @default(pending)
-  user         User              @relation(fields: [username], references: [username])
+  user         User              @relation(fields: [username], references: [username], onDelete: Cascade)
   challenge    Challenge[]
 }
 

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -47,6 +47,13 @@ async function seed() {
         email: 'user3@myseneca.ca',
         group: 'mycustomdomain-admins',
       },
+      {
+        username: 'user4',
+        displayName: 'Deactivated User',
+        email: 'user4@myseneca.ca',
+        group: 'mycustomdomain-students',
+        deactivated: true,
+      },
     ],
   });
 

--- a/test/unit/user.server.test.ts
+++ b/test/unit/user.server.test.ts
@@ -1,0 +1,71 @@
+import {
+  createUser,
+  checkUsernameExists,
+  deactivateUserByUsername,
+  deleteUserByUsername,
+  isDeactivated,
+} from '~/models/user.server';
+
+import type { User } from '@prisma/client';
+
+describe('deactivateUserByUsername()', () => {
+  let user: User;
+
+  beforeAll(async () => {
+    user = await createUser('test_user_1', 'Test', 'testuser1@domain.com', 'test');
+  });
+
+  afterAll(async () => {
+    await deleteUserByUsername(user.username);
+  });
+
+  test('sets deactivated flag to true', async () => {
+    user = await deactivateUserByUsername(user.username);
+    expect(user.deactivated).toBe(true);
+  });
+});
+
+describe('deleteUserByUsername', () => {
+  let user: User;
+
+  beforeAll(async () => {
+    user = await createUser('test_user_1', 'Test', 'testuser1@domain.com', 'test');
+  });
+
+  test('deletes user with provided username', async () => {
+    await deleteUserByUsername(user.username);
+    const userExists = await checkUsernameExists(user.username);
+    expect(userExists).toBe(false);
+  });
+});
+
+describe('isDeactivated()', () => {
+  let activeUser: User;
+  let deactivatedUser: User;
+
+  beforeAll(async () => {
+    activeUser = await createUser('test_user_1', 'Test', 'testuser2@domain.com', 'test');
+    deactivatedUser = await createUser('test_user_2', 'Test', 'testuser3@domain.com', 'test');
+    deactivatedUser = await deactivateUserByUsername(deactivatedUser.username);
+  });
+
+  afterAll(async () => {
+    await deleteUserByUsername(activeUser.username);
+    await deleteUserByUsername(deactivatedUser.username);
+  });
+
+  test('returns true for deactivated user', async () => {
+    const result = await isDeactivated(deactivatedUser.username);
+    expect(result).toBe(true);
+  });
+
+  test('returns false for active user', async () => {
+    const result = await isDeactivated(activeUser.username);
+    expect(result).toBe(false);
+  });
+
+  test('returns undefined when no user is found', async () => {
+    const result = await isDeactivated('invalid username');
+    expect(result).toBe(undefined);
+  });
+});


### PR DESCRIPTION
Resolves #318 

This is part of the work needed to allow us to deactivate users before deleting them

## Changes made
- Added a `deactivated` flag to the user model, with a default value of `false`
- Updated the seed file to create a deactivated user
- Added methods to `user.server.ts` to
  - deactivate user by a username
  - delete user by username. This is currently only used in tests to clean up the database but could also be used in the deletion process we are implementing
  - return if a user is deactivated given a username. This returns undefined if no user is found for the provided username
- Added tests for the new methods