### PR TITLE
Disable actions for inactive records

### DIFF
--- a/app/components/domains-table.tsx
+++ b/app/components/domains-table.tsx
@@ -132,6 +132,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                 const isLoading =
                   transition.state === 'submitting' &&
                   Number(transition.submission.formData.get('id')) === dnsRecord.id;
+                const isRecordActive = dnsRecord.status === 'active';
 
                 return (
                   <Tr key={dnsRecord.id}>
@@ -177,6 +178,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                   aria-label="Refresh domain"
                                   variant="ghost"
                                   type="submit"
+                                  isDisabled={!isRecordActive}
                                 />
                               </Tooltip>
                             </Form>
@@ -191,6 +193,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                 aria-label="Edit domain"
                                 variant="ghost"
                                 mr="1"
+                                isDisabled={!isRecordActive}
                               />
                             </Tooltip>
                             <Tooltip label="Delete domain">
@@ -200,6 +203,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                 aria-label="Delete domain"
                                 variant="ghost"
                                 type="submit"
+                                isDisabled={!isRecordActive}
                               />
                             </Tooltip>
                           </Flex>

--- a/app/routes/__index/domains/$dnsRecordId.tsx
+++ b/app/routes/__index/domains/$dnsRecordId.tsx
@@ -25,6 +25,10 @@ export const loader = async ({ request, params }: LoaderArgs) => {
     });
   }
 
+  if (record.status !== 'active') {
+    return redirect('/domains');
+  }
+
   return typedjson(record);
 };
 

--- a/app/routes/__index/domains/index.tsx
+++ b/app/routes/__index/domains/index.tsx
@@ -51,6 +51,12 @@ export const action = async ({ request }: ActionArgs) => {
     });
   }
 
+  if (record.status !== 'active') {
+    throw new Response('Record is not active, action forbiden', {
+      status: 403,
+    });
+  }
+
   switch (intent) {
     case 'renew-record':
       await renewDnsRecordById(record.id);


### PR DESCRIPTION
- disables action buttons for the record which is not active
- throw error if the action is performed on an inactive record 
- redirect back to the records list if the user tries to access the edit page on the inactive record

<img width="1114" alt="image" src="https://user-images.githubusercontent.com/32075241/226149048-31380cd9-0576-45bd-81a7-1703f8b827bd.png">


closes #361 