### PR TITLE
Limit the number of records per user

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,3 +36,6 @@ SAML_IDP_METADATA_PATH=config/idp-metadata-dev.xml
 EXPIRATION_REPEAT_FREQUENCY_MS=86400000
 # 7 * 24 * 60 * 60 * 1000 = 604800000 (7 days)
 JOB_REMOVAL_FREQUENCY_MS=604800000
+
+# Limit the maximum number of records per user
+USER_RECORD_LIMIT=20

--- a/app/models/record.server.ts
+++ b/app/models/record.server.ts
@@ -7,6 +7,12 @@ import type { Record } from '@prisma/client';
 export const createUserRecord = async (
   data: Pick<Record, 'username' | 'type' | 'subdomain' | 'value'>
 ) => {
+  if (process.env.USER_RECORD_LIMIT) {
+    if ((await getUserRecordCount(data.username)) >= Number(process.env.USER_RECORD_LIMIT)) {
+      throw new Error('User has reached the maximum number of records');
+    }
+  }
+
   if (await doesRecordExist(data)) {
     throw new Error('Record already exists');
   }


### PR DESCRIPTION
Close #110 

- This PR will limit the user to have more than the configurable number of records. 
- This configurable number is set as MAX_USER_RECORD_LIMIT in `.env`
- If MAX_USER_RECORD_LIMIT is not set, 5 will be stored in MAX_USER_RECORD_LIMIT

