### PR TITLE
Add webhook/ with webhook JSON config and deploy.sh with docs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -314,12 +314,14 @@ jobs:
             # cache node modules using the same key as restore.
           key: ${{ steps.node_modules-cache-restore.outputs.cache-primary-key }}
 
-  Starchart-Docker:
+  Docker-Build-Deploy:
     # We'll only build and push when landing on main, not for PRs
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     # Don't bother unless everything else passes
     needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
+    env:
+      IMAGE: ghcr.io/DevelopingSpace/starchart
     permissions:
       contents: read
       packages: write
@@ -327,18 +329,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
 
+      - name: Define GITHUB_SHORT_SHA
+        run: echo "GITHUB_SHA_SHORT=$(echo $GITHUB_SHA | cut -c 1-6)" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-
-      - name: Extract Docker metadata from git info
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/DevelopingSpace/starchart
-          flavor: latest=true
-          tags: |
-            type=ref,event=branch
-            type=sha
 
       - name: Log in to the GitHub Container Registry
         uses: docker/login-action@v2
@@ -354,5 +349,16 @@ jobs:
           build-args: |
             SAML_IDP_METADATA_PATH=./config/idp-metadata-staging.xml
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: |
+            ${{ env.IMAGE }}:sha-${{ env.GITHUB_SHA_SHORT }}, \
+            ${{ env.IMAGE }}:main, \
+            ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Staging via Webhook
+        uses: navied/secure-actions-webhook@0.2.0
+        env:
+          HMAC_SECRET: ${{ secrets.WEBHOOK_STAGING_SECRET }}
+        with:
+          url: https://mycustomdomain-dev.senecacollege.ca/hooks/deploy
+          hmacSecret: ${{ env.HMAC_SECRET }}
+          data: '{"tag": "sha-${{ env.GITHUB_SHA_SHORT }}"}'

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -1,0 +1,34 @@
+# Starchart Deploy Webhook
+
+Starchart uses a GitHub Actions Workflow to automate deployment to staging and production. This is done using [webhook](https://github.com/adnanh/webhook).
+
+## Setup
+
+The `deploy.sh` file and `hooks.json` should be placed together, and `hooks.json` updated to include the correct paths:
+
+```json
+[
+  {
+    "id": "deploy",
+    "execute-command": "/path/deploy.sh",
+    "command-working-directory": "/path",
+```
+
+An HMAC secret needs to be installed in GitHub Actions Encrypted Secrets, as well as in the `hooks.json` file:
+
+```json
+"trigger-rule": {
+  "match": {
+    "type": "payload-hmac-sha256",
+    "secret": "TODO: update me to match secret stored in GitHub Actions...",
+    "parameter": {
+      "source": "header",
+      "name": "X-Hub-Signature"
+    }
+  }
+}
+```
+
+When the webhook is called, the secret is used to create a digest using the body, which can only be verified by using the same secret. The secret itself is never transmitted between GitHub and the deployment server.
+
+The `deploy.sh` script assumes that the Docker image for Starchart is at `ghcr.io/developingspace/starchart` and that the running Docker service is named `starchart_mycustomdomain`. If these are not correct, update the variables in `deploy.sh`.

--- a/webhook/README.md
+++ b/webhook/README.md
@@ -32,3 +32,33 @@ An HMAC secret needs to be installed in GitHub Actions Encrypted Secrets, as wel
 When the webhook is called, the secret is used to create a digest using the body, which can only be verified by using the same secret. The secret itself is never transmitted between GitHub and the deployment server.
 
 The `deploy.sh` script assumes that the Docker image for Starchart is at `ghcr.io/developingspace/starchart` and that the running Docker service is named `starchart_mycustomdomain`. If these are not correct, update the variables in `deploy.sh`.
+
+The `starchart-webhook.service` file defines a [systemd unit file](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_working-with-systemd-unit-files_configuring-basic-system-settings) to be installed on the server.
+
+Make sure that you update this file with the correct paths/ports for your `hooks.json` file, etc. Once it is configured properly, use the following to install and start it:
+
+```sh
+touch /etc/systemd/system/starchart-webhook.service
+chmod 664 /etc/systemd/system/starchart-webhook.service
+systemctl daemon-reload
+systemctl start starchart-webhook.service
+```
+
+> NOTE: updating this may require changes to SELinux
+
+The following commands can also be used to interact with the service:
+
+- `systemctl enable` - at next boot
+- `systemctl disable` - at next boot
+- `systemctl start` - now
+- `systemctl stop` - now
+- `systemctl enable` - `--now` combines enable and start
+- `systemctl disable` - `--now` combines disable and stop
+- `systemctl restart` - sequentially combines stop and start
+- `systemctl status` - show the status of the service
+
+To see the logs for the service, use:
+
+```sh
+sudo journalctl -u starchart-webhook
+```

--- a/webhook/deploy.sh
+++ b/webhook/deploy.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# https://github.com/DevelopingSpace/starchart/pkgs/container/starchart
+IMAGE=ghcr.io/developingspace/starchart
+SERVICE=starchart_mycustomdomain
+
+# We expect to receive the new image tag via the TAG environment variable
+if [[ -z "$TAG" ]]; then
+    logger -s "webhook received, no tag set, skipping."
+    exit 1
+fi
+
+logger -s "webhook received, starting update of ${SERVICE} to ${IMAGE}:${TAG}"
+
+if docker service update --image "$IMAGE":"$TAG" "$SERVICE"; then
+    logger -s "webhook update of ${SERVICE} to ${IMAGE}:${TAG} succeeded."
+    exit 0
+else
+    logger -s "webhook update of ${SERVICE} to ${IMAGE}:${TAG} failed."
+    exit 1
+fi

--- a/webhook/hooks.json
+++ b/webhook/hooks.json
@@ -1,0 +1,24 @@
+[
+  {
+    "id": "deploy",
+    "execute-command": "/home/customdomain/deploy.sh",
+    "command-working-directory": "/home/customdomain",
+    "pass-environment-to-command": [
+      {
+        "source": "payload",
+        "name": "tag",
+        "envname": "TAG"
+      }
+    ],
+    "trigger-rule": {
+      "match": {
+        "type": "payload-hmac-sha256",
+        "secret": "TODO: update me to match secret stored in GitHub Actions...",
+        "parameter": {
+          "source": "header",
+          "name": "X-Hub-Signature"
+        }
+      }
+    }
+  }
+]

--- a/webhook/starchart-webhook.service
+++ b/webhook/starchart-webhook.service
@@ -1,0 +1,23 @@
+# systemd unit file for Starchart Webhook
+[Unit]
+Description=An automated deployment webhook for mycustomdomain (starchart)
+
+Documentation=https://github.com/DevelopingSpace/starchart
+
+# Start after the network is up
+After=network.target
+
+[Service]
+Type=simple
+
+# See https://github.com/adnanh/webhook 
+# Set the path to hooks.json and port to use
+ExecStart=webhook -hooks /path/to/hooks.json -port 8000
+# Specify these if want/need for the above to run
+#WorkingDirectory=
+#User=
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
Closes #77
Closes #76
Closes #74
Closes #50

This finishes the work begun in #57 to get our deployment webhook in place.  ITS wants it to run outside of Docker, and has already installed `webhook` on the manager nodes.

This is the first of at least 2 parts to get this completed.  I need to land the major bits here, then test it and adjust and document things in a follow-up.

The main points here are as follows:

1. On staging (and later production), we'll run a [webhook server](https://github.com/adnanh/webhook).  It will listen on :8000 and ITS will route anything that comes to `/hooks/*` to this server.
2. The webhook will listen for `deploy` messages from GitHub, which will include 2 things.  First a new `tag` to use with Docker.  When we update to a new version on `main`, this will send that image tag so it can be deployed; second, we'll send a digest created with a secret.  Our deployment servers will only respond to webhooks that can sign the body (i.e., no one else can hit this endpoint)
3. Assuming the webhook can be verified by the server (calculating the secret + body to see if it matches the digest), the `deploy.sh` script will be run.  The new `tag` will be sent along as an ENV var.  Docker will try to update the starchart image to the new tag.

As we discussed in #291, I'm not doing any database migration/syncing in here.  Any changes to the database schema would require a manual shut-down and update of the DB first.  It would be good to get to an automated version of this some day, but not in this PR.