### PR TITLE
Add limiter to dns workers

### DIFF
--- a/app/queues/dns/workers/dns-update-worker.server.ts
+++ b/app/queues/dns/workers/dns-update-worker.server.ts
@@ -45,5 +45,11 @@ export const dnsUpdateWorker = new Worker<DnsUpdaterData, DnsRecordUpdateJobResu
       throw error;
     }
   },
-  { connection: redis }
+  {
+    connection: redis,
+    limiter: {
+      max: 3,
+      duration: 1_000,
+    },
+  }
 );

--- a/app/queues/dns/workers/poll-dns-status-worker.server.ts
+++ b/app/queues/dns/workers/poll-dns-status-worker.server.ts
@@ -28,5 +28,11 @@ export const pollDnsStatusWorker = new Worker<void, PollDnsStatusJobResult>(
     }
     return status;
   },
-  { connection: redis }
+  {
+    connection: redis,
+    limiter: {
+      max: 3,
+      duration: 1_000,
+    },
+  }
 );


### PR DESCRIPTION
Close #382 

This is to avoid Route 53 throttling issue which allows 5 requests per second. To set a buffer to the limit, Bullmq limiter is set to 3 per second. Limiter is not set to non Route 53 related worker. 