### PR TITLE
Don't fail on delete with missing record; update record status early

### DIFF
--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -51,29 +51,21 @@ export function createDnsRecord(
   return prisma.dnsRecord.create({ data: { ...data, expiresAt, status } });
 }
 
+// Update an existing DNS Record's data, or status, or both.
 export function updateDnsRecordById(
-  data: Pick<DnsRecord, 'id' | 'type' | 'subdomain' | 'value'> &
-    Partial<Pick<DnsRecord, 'description' | 'course' | 'ports'>>
+  id: DnsRecord['id'],
+  data:
+    | Pick<DnsRecord, 'status'>
+    | (Pick<DnsRecord, 'type' | 'subdomain' | 'value'> &
+        Partial<Pick<DnsRecord, 'description' | 'course' | 'ports' | 'status'>>)
 ) {
-  const { id, ...values } = data;
   return prisma.dnsRecord.update({
     where: { id },
     data: {
-      ...values,
-      expiresAt: dayjs().set('month', 6).toDate(),
-    },
-  });
-}
-
-export function updateDnsRecordStatusById(id: DnsRecord['id'], status: DnsRecord['status']) {
-  const expireToSet = dayjs().set('month', 6).toDate();
-  return prisma.dnsRecord.update({
-    where: {
-      id,
-    },
-    data: {
-      status,
-      expiresAt: status === DnsRecordStatus.active ? expireToSet : undefined,
+      ...data,
+      // If the record is changing to the `active` status, update expiry too
+      expiresAt:
+        data.status === DnsRecordStatus.active ? dayjs().set('month', 6).toDate() : undefined,
     },
   });
 }

--- a/app/queues/dns/workers/dns-update-worker.server.ts
+++ b/app/queues/dns/workers/dns-update-worker.server.ts
@@ -17,7 +17,11 @@ export interface DnsUpdaterData {
   value: DnsRecord['value'];
 }
 
-export type DnsRecordUpdateJobResult = string;
+// We expect to get back a Change ID, so that we can wait on Route53
+// to sync all changes.  However, in the case of delete, when a record
+// is already gone from Route53, there is nothing to wait for, so there
+// will be no Change ID (null)
+export type DnsRecordUpdateJobResult = string | null;
 
 export const dnsUpdateWorker = new Worker<DnsUpdaterData, DnsRecordUpdateJobResult>(
   dnsUpdateQueueName,

--- a/app/queues/dns/workers/poll-dns-status-worker.server.ts
+++ b/app/queues/dns/workers/poll-dns-status-worker.server.ts
@@ -21,8 +21,14 @@ export const pollDnsStatusWorker = new Worker<void, PollDnsStatusJobResult>(
 
     const [changeId] = Object.values(childrenValues);
 
-    const status = (await getChangeStatus(changeId)) as PollDnsStatusJobResult;
+    // If we don't get back a Change ID, it means there's nothing to wait on
+    // and everything is already in sync.
+    if (!changeId) {
+      return 'INSYNC';
+    }
 
+    // Otherwise, wait on Route53 to sync this change
+    const status = (await getChangeStatus(changeId)) as PollDnsStatusJobResult;
     if (status === 'PENDING') {
       throw new Error('Change status is still pending');
     }

--- a/app/queues/dns/workers/sync-db-status-worker.server.ts
+++ b/app/queues/dns/workers/sync-db-status-worker.server.ts
@@ -2,7 +2,7 @@ import { UnrecoverableError, Worker } from 'bullmq';
 import { DnsRecordStatus } from '@prisma/client';
 import { redis } from '~/lib/redis.server';
 import logger from '~/lib/logger.server';
-import { deleteDnsRecordById, updateDnsRecordStatusById } from '~/models/dns-record.server';
+import { deleteDnsRecordById, updateDnsRecordById } from '~/models/dns-record.server';
 import type { PollDnsStatusJobResult } from './poll-dns-status-worker.server';
 import { pollDnsStatusQueueName } from './poll-dns-status-worker.server';
 
@@ -47,7 +47,7 @@ export const syncDbStatusWorker = new Worker<DbRecordSynchronizerData>(
           break;
         default:
           const status = dnsStatus === 'INSYNC' ? DnsRecordStatus.active : DnsRecordStatus.error;
-          await updateDnsRecordStatusById(id, status);
+          await updateDnsRecordById(id, { status });
           break;
       }
     } catch (error) {

--- a/test/unit/dns.server.test.ts
+++ b/test/unit/dns.server.test.ts
@@ -116,18 +116,17 @@ describe('DNS server lib function test', () => {
       '192.168.0.0'
     );
 
-    expect(changeId.length).toBeGreaterThan(1);
+    expect(changeId?.length).toBeGreaterThan(1);
   });
 
-  test('deleteDnsRecord() throws an error when attempting to delete non existing record', async () => {
-    await expect(
-      deleteDnsRecord(
-        username,
-        DnsRecordType.A,
-        `not-exist.${username}.${rootDomain}`,
-        '192.168.0.1'
-      )
-    ).rejects.toThrow();
+  test('deleteDnsRecord() returns null for Change ID when attempting to delete non existing record', async () => {
+    const changeId = await deleteDnsRecord(
+      username,
+      DnsRecordType.A,
+      `not-exist.${username}.${rootDomain}`,
+      '192.168.0.1'
+    );
+    expect(changeId).toBe(null);
   });
 
   test('deleteDnsRecord() throws an error when invalid name or value is provided', async () => {
@@ -135,7 +134,7 @@ describe('DNS server lib function test', () => {
       deleteDnsRecord(
         username,
         DnsRecordType.A,
-        `invalid_name.${username}.${rootDomain}`,
+        `inv@lid_name.${username}.${rootDomain}`,
         '192.168.0.2'
       )
     ).rejects.toThrow();


### PR DESCRIPTION
Fixes #360
Fixes #390

This makes 2 changes to how the DNS logic works:

1. When we try to delete a record from Route53, we first check if the record is there.  If it is not, we are already done, and don't fail.  Doing this requires some changes to other parts of the code that expect a Change ID, which is now going to be `null`.  We simply skip doing the `insync` checks with Route53 and report back that the change is ready.
2. For all DNS flows, the database is updated first, so that the UI can poll for changes.

To test this:

1. Create a new domain, make sure the pending/active UI works
2. Update the domain, make sure the pending/active UI works
3. Delete the domain, make sure the pending/active UI works