### PR TITLE
Update vitest config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ node_modules
 /playwright-report/
 /playwright/.cache/
 /test/e2e/.auth
+/coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,7 @@
         "@types/react-dom": "^18.0.11",
         "@types/validator": "^13.7.12",
         "@vitejs/plugin-react": "^3.0.1",
-        "@vitest/coverage-c8": "^0.28.5",
+        "@vitest/coverage-istanbul": "^0.29.7",
         "c8": "^7.13.0",
         "cookie": "^0.5.0",
         "dotenv": "^16.0.3",
@@ -7166,198 +7166,24 @@
         "vite": "^4.1.0-beta.0"
       }
     },
-    "node_modules/@vitest/coverage-c8": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.28.5.tgz",
-      "integrity": "sha512-zCNyurjudoG0BAqAgknvlBhkV2V9ZwyYLWOAGtHSDhL/St49MJT+V2p1G0yPaoqBbKOTATVnP5H2p1XL15H75g==",
+    "node_modules/@vitest/coverage-istanbul": {
+      "version": "0.29.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-0.29.7.tgz",
+      "integrity": "sha512-PPnvqEkwSSgjJ1cOgkm5g49/3UiPGPLC5qmWvrx2ITF9AfN2NejnjaEKxoYrX7oQQyBFgf/ph/BraxsqOOo+Kg==",
       "dev": true,
       "dependencies": {
-        "c8": "^7.12.0",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.3.1",
-        "vitest": "0.28.5"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/@vitest/expect": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.28.5.tgz",
-      "integrity": "sha512-gqTZwoUTwepwGIatnw4UKpQfnoyV0Z9Czn9+Lo2/jLIt4/AXLTn+oVZxlQ7Ng8bzcNkR+3DqLJ08kNr8jRmdNQ==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/spy": "0.28.5",
-        "@vitest/utils": "0.28.5",
-        "chai": "^4.3.7"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/@vitest/runner": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.28.5.tgz",
-      "integrity": "sha512-NKkHtLB+FGjpp5KmneQjTcPLWPTDfB7ie+MmF1PnUBf/tGe2OjGxWyB62ySYZ25EYp9krR5Bw0YPLS/VWh1QiA==",
-      "dev": true,
-      "dependencies": {
-        "@vitest/utils": "0.28.5",
-        "p-limit": "^4.0.0",
-        "pathe": "^1.1.0"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/@vitest/spy": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.28.5.tgz",
-      "integrity": "sha512-7if6rsHQr9zbmvxN7h+gGh2L9eIIErgf8nSKYDlg07HHimCxp4H6I/X/DPXktVPPLQfiZ1Cw2cbDIx9fSqDjGw==",
-      "dev": true,
-      "dependencies": {
-        "tinyspy": "^1.0.2"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/@vitest/utils": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.28.5.tgz",
-      "integrity": "sha512-UyZdYwdULlOa4LTUSwZ+Paz7nBHGTT72jKwdFSV4IjHF1xsokp+CabMdhjvVhYwkLfO88ylJT46YMilnkSARZA==",
-      "dev": true,
-      "dependencies": {
-        "cli-truncate": "^3.1.0",
-        "diff": "^5.1.0",
-        "loupe": "^2.3.6",
-        "picocolors": "^1.0.0",
-        "pretty-format": "^27.5.1"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.3.1"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/p-limit": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-      "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-      "dev": true,
-      "dependencies": {
-        "yocto-queue": "^1.0.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/vite-node": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.5.tgz",
-      "integrity": "sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==",
-      "dev": true,
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.3.4",
-        "mlly": "^1.1.0",
-        "pathe": "^1.1.0",
-        "picocolors": "^1.0.0",
-        "source-map": "^0.6.1",
-        "source-map-support": "^0.5.21",
-        "vite": "^3.0.0 || ^4.0.0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": ">=v14.16.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/vitest": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.28.5.tgz",
-      "integrity": "sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==",
-      "dev": true,
-      "dependencies": {
-        "@types/chai": "^4.3.4",
-        "@types/chai-subset": "^1.3.3",
-        "@types/node": "*",
-        "@vitest/expect": "0.28.5",
-        "@vitest/runner": "0.28.5",
-        "@vitest/spy": "0.28.5",
-        "@vitest/utils": "0.28.5",
-        "acorn": "^8.8.1",
-        "acorn-walk": "^8.2.0",
-        "cac": "^6.7.14",
-        "chai": "^4.3.7",
-        "debug": "^4.3.4",
-        "local-pkg": "^0.4.2",
-        "pathe": "^1.1.0",
-        "picocolors": "^1.0.0",
-        "source-map": "^0.6.1",
-        "std-env": "^3.3.1",
-        "strip-literal": "^1.0.0",
-        "tinybench": "^2.3.1",
-        "tinypool": "^0.3.1",
-        "tinyspy": "^1.0.2",
-        "vite": "^3.0.0 || ^4.0.0",
-        "vite-node": "0.28.5",
-        "why-is-node-running": "^2.2.2"
-      },
-      "bin": {
-        "vitest": "vitest.mjs"
-      },
-      "engines": {
-        "node": ">=v14.16.0"
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.2.1",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "test-exclude": "^6.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       },
       "peerDependencies": {
-        "@edge-runtime/vm": "*",
-        "@vitest/browser": "*",
-        "@vitest/ui": "*",
-        "happy-dom": "*",
-        "jsdom": "*"
-      },
-      "peerDependenciesMeta": {
-        "@edge-runtime/vm": {
-          "optional": true
-        },
-        "@vitest/browser": {
-          "optional": true
-        },
-        "@vitest/ui": {
-          "optional": true
-        },
-        "happy-dom": {
-          "optional": true
-        },
-        "jsdom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vitest/coverage-c8/node_modules/yocto-queue": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-      "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "vitest": ">=0.28.0 <1"
       }
     },
     "node_modules/@vitest/expect": {
@@ -12920,6 +12746,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/istanbul-reports": {
@@ -25270,137 +25119,18 @@
         "react-refresh": "^0.14.0"
       }
     },
-    "@vitest/coverage-c8": {
-      "version": "0.28.5",
-      "resolved": "https://registry.npmjs.org/@vitest/coverage-c8/-/coverage-c8-0.28.5.tgz",
-      "integrity": "sha512-zCNyurjudoG0BAqAgknvlBhkV2V9ZwyYLWOAGtHSDhL/St49MJT+V2p1G0yPaoqBbKOTATVnP5H2p1XL15H75g==",
+    "@vitest/coverage-istanbul": {
+      "version": "0.29.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-istanbul/-/coverage-istanbul-0.29.7.tgz",
+      "integrity": "sha512-PPnvqEkwSSgjJ1cOgkm5g49/3UiPGPLC5qmWvrx2ITF9AfN2NejnjaEKxoYrX7oQQyBFgf/ph/BraxsqOOo+Kg==",
       "dev": true,
       "requires": {
-        "c8": "^7.12.0",
-        "picocolors": "^1.0.0",
-        "std-env": "^3.3.1",
-        "vitest": "0.28.5"
-      },
-      "dependencies": {
-        "@vitest/expect": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-0.28.5.tgz",
-          "integrity": "sha512-gqTZwoUTwepwGIatnw4UKpQfnoyV0Z9Czn9+Lo2/jLIt4/AXLTn+oVZxlQ7Ng8bzcNkR+3DqLJ08kNr8jRmdNQ==",
-          "dev": true,
-          "requires": {
-            "@vitest/spy": "0.28.5",
-            "@vitest/utils": "0.28.5",
-            "chai": "^4.3.7"
-          }
-        },
-        "@vitest/runner": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-0.28.5.tgz",
-          "integrity": "sha512-NKkHtLB+FGjpp5KmneQjTcPLWPTDfB7ie+MmF1PnUBf/tGe2OjGxWyB62ySYZ25EYp9krR5Bw0YPLS/VWh1QiA==",
-          "dev": true,
-          "requires": {
-            "@vitest/utils": "0.28.5",
-            "p-limit": "^4.0.0",
-            "pathe": "^1.1.0"
-          }
-        },
-        "@vitest/spy": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-0.28.5.tgz",
-          "integrity": "sha512-7if6rsHQr9zbmvxN7h+gGh2L9eIIErgf8nSKYDlg07HHimCxp4H6I/X/DPXktVPPLQfiZ1Cw2cbDIx9fSqDjGw==",
-          "dev": true,
-          "requires": {
-            "tinyspy": "^1.0.2"
-          }
-        },
-        "@vitest/utils": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-0.28.5.tgz",
-          "integrity": "sha512-UyZdYwdULlOa4LTUSwZ+Paz7nBHGTT72jKwdFSV4IjHF1xsokp+CabMdhjvVhYwkLfO88ylJT46YMilnkSARZA==",
-          "dev": true,
-          "requires": {
-            "cli-truncate": "^3.1.0",
-            "diff": "^5.1.0",
-            "loupe": "^2.3.6",
-            "picocolors": "^1.0.0",
-            "pretty-format": "^27.5.1"
-          }
-        },
-        "diff": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-          "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
-          "dev": true
-        },
-        "p-limit": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-4.0.0.tgz",
-          "integrity": "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==",
-          "dev": true,
-          "requires": {
-            "yocto-queue": "^1.0.0"
-          }
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "dev": true
-        },
-        "vite-node": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-0.28.5.tgz",
-          "integrity": "sha512-LmXb9saMGlrMZbXTvOveJKwMTBTNUH66c8rJnQ0ZPNX+myPEol64+szRzXtV5ORb0Hb/91yq+/D3oERoyAt6LA==",
-          "dev": true,
-          "requires": {
-            "cac": "^6.7.14",
-            "debug": "^4.3.4",
-            "mlly": "^1.1.0",
-            "pathe": "^1.1.0",
-            "picocolors": "^1.0.0",
-            "source-map": "^0.6.1",
-            "source-map-support": "^0.5.21",
-            "vite": "^3.0.0 || ^4.0.0"
-          }
-        },
-        "vitest": {
-          "version": "0.28.5",
-          "resolved": "https://registry.npmjs.org/vitest/-/vitest-0.28.5.tgz",
-          "integrity": "sha512-pyCQ+wcAOX7mKMcBNkzDwEHRGqQvHUl0XnoHR+3Pb1hytAHISgSxv9h0gUiSiYtISXUU3rMrKiKzFYDrI6ZIHA==",
-          "dev": true,
-          "requires": {
-            "@types/chai": "^4.3.4",
-            "@types/chai-subset": "^1.3.3",
-            "@types/node": "*",
-            "@vitest/expect": "0.28.5",
-            "@vitest/runner": "0.28.5",
-            "@vitest/spy": "0.28.5",
-            "@vitest/utils": "0.28.5",
-            "acorn": "^8.8.1",
-            "acorn-walk": "^8.2.0",
-            "cac": "^6.7.14",
-            "chai": "^4.3.7",
-            "debug": "^4.3.4",
-            "local-pkg": "^0.4.2",
-            "pathe": "^1.1.0",
-            "picocolors": "^1.0.0",
-            "source-map": "^0.6.1",
-            "std-env": "^3.3.1",
-            "strip-literal": "^1.0.0",
-            "tinybench": "^2.3.1",
-            "tinypool": "^0.3.1",
-            "tinyspy": "^1.0.2",
-            "vite": "^3.0.0 || ^4.0.0",
-            "vite-node": "0.28.5",
-            "why-is-node-running": "^2.2.2"
-          }
-        },
-        "yocto-queue": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.0.0.tgz",
-          "integrity": "sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==",
-          "dev": true
-        }
+        "istanbul-lib-coverage": "^3.2.0",
+        "istanbul-lib-instrument": "^5.2.1",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.1",
+        "istanbul-reports": "^3.1.5",
+        "test-exclude": "^6.0.0"
       }
     },
     "@vitest/expect": {
@@ -29559,6 +29289,25 @@
         "istanbul-lib-coverage": "^3.0.0",
         "make-dir": "^3.0.0",
         "supports-color": "^7.1.0"
+      }
+    },
+    "istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "istanbul-reports": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@types/react-dom": "^18.0.11",
     "@types/validator": "^13.7.12",
     "@vitejs/plugin-react": "^3.0.1",
-    "@vitest/coverage-c8": "^0.28.5",
+    "@vitest/coverage-istanbul": "^0.29.7",
     "c8": "^7.13.0",
     "cookie": "^0.5.0",
     "dotenv": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "start": "cross-env NODE_ENV=production node ./build/server.js",
     "start:e2e": "cross-env NODE_ENV=test node --require dotenv/config ./build/server.js",
     "test": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest",
+    "test:coverage": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest --coverage",
     "test:e2e:dev": "cross-env PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test dev http://localhost:8080 \"playwright test\"",
     "pretest:e2e:run": "cross-env NODE_ENV=test SECRETS_OVERRIDE=1 run-s build",
     "test:e2e:run": "cross-env SECRETS_OVERRIDE=1 PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test start:e2e http://localhost:8080 \"playwright test\"",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "start": "cross-env NODE_ENV=production node ./build/server.js",
     "start:e2e": "cross-env NODE_ENV=test node --require dotenv/config ./build/server.js",
     "test": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest",
-    "test:coverage": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest --coverage",
+    "test:coverage": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest run --coverage",
     "test:e2e:dev": "cross-env PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test dev http://localhost:8080 \"playwright test\"",
     "pretest:e2e:run": "cross-env NODE_ENV=test SECRETS_OVERRIDE=1 run-s build",
     "test:e2e:run": "cross-env SECRETS_OVERRIDE=1 PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test start:e2e http://localhost:8080 \"playwright test\"",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,12 +9,8 @@ export default defineConfig({
   plugins: [react(), tsconfigPaths()],
   test: {
     globals: true,
-    environment: 'happy-dom',
     setupFiles: ['./test/unit/setup-test-env.ts'],
-    include: [
-      './app/**/unit/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-      './test/unit/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}',
-    ],
-    watchExclude: ['.*\\/node_modules\\/.*', '.*\\/build\\/.*', '.*\\/postgres-data\\/.*'],
+    include: ['./test/unit/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    watchExclude: ['.*\\/node_modules\\/.*', '.*\\/build\\/.*', '.*\\/mysql-data\\/.*'],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,5 +12,8 @@ export default defineConfig({
     setupFiles: ['./test/unit/setup-test-env.ts'],
     include: ['./test/unit/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
     watchExclude: ['.*\\/node_modules\\/.*', '.*\\/build\\/.*', '.*\\/mysql-data\\/.*'],
+    coverage: {
+      provider: 'istanbul',
+    },
   },
 });


### PR DESCRIPTION
Resolves #134 

Make a few changes to our vitest config:
- Added a `test:coverage` script to run tests with coverage. This shows the coverage report in the terminal and generated a html report in `coverage` folder
- Removed c8 and replaced it with istanbul which will be used to generate the coverage. This was mainly done because there were issues getting the default `c8` to properly generate coverage as no files were displayed in the coverage. Even with the `all` files setting, none of the files showed anything being covered by tests
- Added `coverage` folder to `.gitignore`
- Updated `watchExclude` to exclude our `mysql-data` folder
- Removed redundant `include` in vitest.config