### PR TITLE
Update playwright and add --ui script via e2e

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "zodix": "^0.4.0"
       },
       "devDependencies": {
-        "@playwright/test": "^1.31.0",
+        "@playwright/test": "^1.32.0",
         "@remix-run/dev": "^1.14.3",
         "@remix-run/eslint-config": "^1.14.3",
         "@types/compression": "^1.7.2",
@@ -5207,13 +5207,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.0.tgz",
-      "integrity": "sha512-Ys5s/06Dg9g3zAIdCIb/UOBYim3U7Zjb3DvC6XBtnRmnglH5O47iwYzmtxXu9fhSyzI2Jn28apkXIOD81GgCdw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
+      "integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
       "dev": true,
       "dependencies": {
         "@types/node": "*",
-        "playwright-core": "1.31.0"
+        "playwright-core": "1.32.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -15659,9 +15659,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.0.tgz",
-      "integrity": "sha512-/KquBjS5DcASCh8cGeNVHuC0kyb7c9plKTwaKxgOGtxT7+DZO2fjmFvPDBSXslEIK5CeOO/2kk5rOCktFXKEdA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
       "dev": true,
       "bin": {
         "playwright": "cli.js"
@@ -23753,14 +23753,14 @@
       }
     },
     "@playwright/test": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.31.0.tgz",
-      "integrity": "sha512-Ys5s/06Dg9g3zAIdCIb/UOBYim3U7Zjb3DvC6XBtnRmnglH5O47iwYzmtxXu9fhSyzI2Jn28apkXIOD81GgCdw==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.32.0.tgz",
+      "integrity": "sha512-zOdGloaF0jeec7hqoLqM5S3L2rR4WxMJs6lgiAeR70JlH7Ml54ZPoIIf3X7cvnKde3Q9jJ/gaxkFh8fYI9s1rg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
         "fsevents": "2.3.2",
-        "playwright-core": "1.31.0"
+        "playwright-core": "1.32.0"
       }
     },
     "@popperjs/core": {
@@ -31351,9 +31351,9 @@
       }
     },
     "playwright-core": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.31.0.tgz",
-      "integrity": "sha512-/KquBjS5DcASCh8cGeNVHuC0kyb7c9plKTwaKxgOGtxT7+DZO2fjmFvPDBSXslEIK5CeOO/2kk5rOCktFXKEdA==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.32.0.tgz",
+      "integrity": "sha512-Z9Ij17X5Z3bjpp6XKujGBp9Gv4eViESac9aDmwgQFUEJBW0K80T21m/Z+XJQlu4cNsvPygw33b6V1Va6Bda5zQ==",
       "dev": true
     },
     "popmotion": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "start:e2e": "cross-env NODE_ENV=test node --require dotenv/config ./build/server.js",
     "test": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest",
     "test:coverage": "cross-env SECRETS_OVERRIDE=1 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' NODE_OPTIONS=--require=dotenv/config vitest run --coverage",
+    "e2e": "cross-env PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test dev http://localhost:8080 \"playwright test --ui\"",
     "test:e2e:dev": "cross-env PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test dev http://localhost:8080 \"playwright test\"",
     "pretest:e2e:run": "cross-env NODE_ENV=test SECRETS_OVERRIDE=1 run-s build",
     "test:e2e:run": "cross-env SECRETS_OVERRIDE=1 PORT=8080 DATABASE_URL='mysql://root:root_password@127.0.0.1:3306/starchart_test' start-server-and-test start:e2e http://localhost:8080 \"playwright test\"",
@@ -73,7 +74,7 @@
     "zodix": "^0.4.0"
   },
   "devDependencies": {
-    "@playwright/test": "^1.31.0",
+    "@playwright/test": "^1.32.0",
     "@remix-run/dev": "^1.14.3",
     "@remix-run/eslint-config": "^1.14.3",
     "@types/compression": "^1.7.2",


### PR DESCRIPTION
Today I was showing @Eakam1007 the new release of Playwright, and the amazing `--ui` flag they added, see https://www.youtube.com/watch?v=jF0yA-JLQW0

It lets you run your tests in this cool visual timeline view.  I've never seen anything quite like it.

I update our code to use it.  To test:

```
npm install
npm run e2e
```

![image](https://user-images.githubusercontent.com/427398/227069275-64aca34c-c623-42ac-8121-58b454f423b5.png)