### PR TITLE
Add tooltip for optional DNS record info in table

### DIFF
--- a/app/components/dns-record/dns-record-name.tsx
+++ b/app/components/dns-record/dns-record-name.tsx
@@ -1,16 +1,39 @@
-import { Flex, Text } from '@chakra-ui/react';
+import { Flex, Text, Tooltip } from '@chakra-ui/react';
+
+import type { DnsRecord } from '@prisma/client';
 
 interface DnsRecordNameProps {
-  subdomain: string;
+  dnsRecord: DnsRecord;
   baseDomain: string;
 }
 
-const DnsRecordName = ({ subdomain, baseDomain }: DnsRecordNameProps) => {
-  return (
+// If there is addition info in the record (optional fields), turn it
+// into a string we can show when hovering. If none of these fields
+// are present, don't bother (undefined)
+function buildInfoTooltip(dnsRecord: DnsRecord) {
+  const info = [];
+
+  if (dnsRecord.description) {
+    // Flatten the string into a single line
+    info.push(dnsRecord.description.replace(/\r?\n/g, ' '));
+  }
+  if (dnsRecord.ports) {
+    info.push(`Ports = ${dnsRecord.ports}`);
+  }
+  if (dnsRecord.course) {
+    info.push(`Course = ${dnsRecord.course}`);
+  }
+
+  return info.length ? info.join(', ') : undefined;
+}
+
+const DnsRecordName = ({ dnsRecord, baseDomain }: DnsRecordNameProps) => {
+  const tooltip = buildInfoTooltip(dnsRecord);
+  const children = (
     <Flex alignItems="flex-end" flexDirection="row">
       <Text>
         <Text as="span" sx={{ fontWeight: 'medium' }}>
-          {subdomain}
+          {dnsRecord.subdomain}
         </Text>
         <Text as="span" color="gray.500">
           .{baseDomain}
@@ -18,6 +41,8 @@ const DnsRecordName = ({ subdomain, baseDomain }: DnsRecordNameProps) => {
       </Text>
     </Flex>
   );
+
+  return tooltip ? <Tooltip label={tooltip}>{children}</Tooltip> : <>{children}</>;
 };
 
 export default DnsRecordName;

--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -14,6 +14,7 @@ import {
   useToast,
   useDisclosure,
   Spinner,
+  HStack,
 } from '@chakra-ui/react';
 import type { DnsRecord, DnsRecordStatus } from '@prisma/client';
 import {
@@ -148,10 +149,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                         <Td>{renderDnsRecordStatus(dnsRecord.status)}</Td>
                         <Td>
                           <Flex justifyContent="space-between" alignItems="center">
-                            <DnsRecordName
-                              subdomain={dnsRecord.subdomain}
-                              baseDomain={baseDomain}
-                            />
+                            <DnsRecordName dnsRecord={dnsRecord} baseDomain={baseDomain} />
                             <Tooltip label="Copy subdomain to clipboard">
                               <IconButton
                                 icon={<CopyIcon color="black" boxSize="5" />}
@@ -186,7 +184,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                           </Flex>
                         </Td>
                         <Td>
-                          <Flex>
+                          <HStack>
                             <Tooltip label="Edit DNS record">
                               <IconButton
                                 onClick={() => onDnsRecordEdit(dnsRecord)}
@@ -207,7 +205,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                 isDisabled={!isDnsRecordDeletable}
                               />
                             </Tooltip>
-                          </Flex>
+                          </HStack>
                         </Td>
                       </>
                     )}


### PR DESCRIPTION
Fixes #304 

If we have optional data for a DNS Record, this shows it in a tooltip when you hover over the name.  If we don't, we don't show anything.  I had thought to use an icon like CloudFlare, but since most records won't have all this data, it seemed like a waste to show it and do nothing with it.  This way the data reveals itself if we have it, but doesn't clutter the UI.

<img width="1186" alt="Screenshot 2023-03-23 at 5 24 19 PM" src="https://user-images.githubusercontent.com/427398/227367445-efafd9d9-64ac-4dbe-9494-af37efda6637.png">

I think we need to fix #425 to test this properly, but you can use `npm run db:studio` to manually enter the values on an existing record.