### PR TITLE
Hide table if no DNS Records exist

### DIFF
--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { AddIcon } from '@chakra-ui/icons';
-import { Button, Container, Flex, Heading, Text } from '@chakra-ui/react';
+import { Button, Center, Container, Flex, Heading, Text } from '@chakra-ui/react';
 import { Link, useRevalidator } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
 import { json } from '@remix-run/node';
@@ -107,17 +107,25 @@ export default function DnsRecordsIndexRoute() {
         <Heading as="h1" size="xl" mt="20">
           DNS Records
         </Heading>
-        <Text maxW="container.sm" mb="4" mt="2">
+        <Text mb="4" mt="2">
           Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
           been the industry's standard dummy text ever since the 1500s, when an unknown printer took
           a galley of type and scrambled it to make a type specimen book.
         </Text>
-        <Flex justifyContent="flex-end">
-          <Link to="/dns-records/new">
-            <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS record</Button>
-          </Link>
-        </Flex>
-        <DnsRecordsTable dnsRecords={dnsRecords} />
+        {dnsRecords.length ? (
+          <Flex justifyContent="flex-end">
+            <Link to="/dns-records/new">
+              <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
+            </Link>
+            <DnsRecordsTable dnsRecords={dnsRecords} />
+          </Flex>
+        ) : (
+          <Center mt="16">
+            <Link to="/dns-records/new">
+              <Button rightIcon={<AddIcon boxSize={3} />}>Create your first DNS Record!</Button>
+            </Link>
+          </Center>
+        )}
       </Flex>
     </Container>
   );

--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -113,12 +113,14 @@ export default function DnsRecordsIndexRoute() {
           a galley of type and scrambled it to make a type specimen book.
         </Text>
         {dnsRecords.length ? (
-          <Flex justifyContent="flex-end">
-            <Link to="/dns-records/new">
-              <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
-            </Link>
+          <>
+            <Flex justifyContent="flex-end" maxW="container.xl">
+              <Link to="/dns-records/new">
+                <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
+              </Link>
+            </Flex>
             <DnsRecordsTable dnsRecords={dnsRecords} />
-          </Flex>
+          </>
         ) : (
           <Center mt="16">
             <Link to="/dns-records/new">


### PR DESCRIPTION
Resolves #403 

This changes the DNS Records tables so that:
- The text container takes up the same width as the DNS Records table. This was done because the DNS Records table takes up the full width
- If there are no DNS Records, a create button will be displayed in the center of the page

#### Without DNS Records
<img width="959" alt="image" src="https://user-images.githubusercontent.com/67077705/227378188-bd25da09-ce87-44b9-b930-b02b5e7c8a23.png">

#### With DNS Records
<img width="959" alt="image" src="https://user-images.githubusercontent.com/67077705/227378044-12e4c3aa-92b5-4334-98c8-57e85770cac2.png">
