### PR TITLE
Improve landing page link accessibility

### DIFF
--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -28,8 +28,8 @@ export default function LandingPageCard({
       <Flex width={{ md: 'xs' }} height={{ sm: 'xl' }} flexDirection="column">
         <Text fontSize={{ base: 'xs', md: 'md' }}>
           {cardDescription}
-          <Text as={Link} to={`${path}/instructions`} color="blue.300">
-            to learn more, see these instructions...
+          <Text as={Link} to={`${path}/instructions`} color="brand.500" textDecor="underline">
+            To learn more, see these instructions...
           </Text>
         </Text>
       </Flex>

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -40,13 +40,13 @@ export default function IndexRoute() {
           path="/dns-records"
           pathName="Manage DNS Records"
           cardName="DNS Records"
-          cardDescription="DNS Record: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book "
+          cardDescription="DNS Record: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. "
         />
         <LandingPageCard
           path="/certificate"
           pathName="Manage Certificate"
           cardName="Certificate"
-          cardDescription="Certificate: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book "
+          cardDescription="Certificate: Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has been the industry's standard dummy text ever since the 1500s, when an unknown printer took a galley of type and scrambled it to make a type specimen book. "
         />
       </Flex>
     </VStack>


### PR DESCRIPTION
Resolves #341 

Changed the color of the link text to use one of your brand colors to increase the contrast and improve accessibility. 
Also modified the link text slightly (by capitalizing the `T`, and making it its own sentence)

<img width="600" alt="image" src="https://user-images.githubusercontent.com/67077705/227426304-2c420a3e-5055-4747-aa20-cde9895792d4.png">
