### PR TITLE
Improve DNS record renew button usability

### DIFF
--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -30,6 +30,7 @@ import DnsRecordDeleteAlertDialog from './dns-record-delete-alert-dialog';
 import { Form, useNavigate, useTransition } from '@remix-run/react';
 import DnsRecordName from './dns-record/dns-record-name';
 import { useUser } from '~/utils';
+import dayjs from 'dayjs';
 
 interface DnsRecordsTableProps {
   dnsRecords: DnsRecord[];
@@ -132,6 +133,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                 const isLoading =
                   transition.state === 'submitting' &&
                   Number(transition.submission.formData.get('id')) === dnsRecord.id;
+                const renewalAllowed = dayjs(dnsRecord.expiresAt).isBefore(dayjs().add(6, 'month'));
                 const isDnsRecordActive = dnsRecord.status === 'active';
                 const isDnsRecordDeletable = dnsRecord.status !== 'pending';
 
@@ -179,7 +181,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                   aria-label="Refresh DNS record"
                                   variant="ghost"
                                   type="submit"
-                                  isDisabled={!isDnsRecordActive}
+                                  isDisabled={!isDnsRecordActive || !renewalAllowed}
                                 />
                               </Tooltip>
                             </Form>

--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -133,7 +133,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                 const isLoading =
                   transition.state === 'submitting' &&
                   Number(transition.submission.formData.get('id')) === dnsRecord.id;
-                const renewalAllowed = dayjs(dnsRecord.expiresAt).isBefore(dayjs().add(6, 'month'));
+                const isRenewable = dayjs(dnsRecord.expiresAt).isBefore(dayjs().add(6, 'month'));
                 const isDnsRecordActive = dnsRecord.status === 'active';
                 const isDnsRecordDeletable = dnsRecord.status !== 'pending';
 
@@ -181,7 +181,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                                   aria-label="Refresh DNS record"
                                   variant="ghost"
                                   type="submit"
-                                  isDisabled={!isDnsRecordActive || !renewalAllowed}
+                                  isDisabled={!isDnsRecordActive || !isRenewable}
                                 />
                               </Tooltip>
                             </Form>

--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -170,7 +170,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                         <Td>{dnsRecord.type}</Td>
                         <Td>{dnsRecord.value}</Td>
                         <Td>
-                          <Flex justifyContent="space-between" alignItems="center">
+                          <Flex alignItems="center">
                             {dnsRecord.expiresAt.toLocaleDateString('en-US')}
                             <Form method="patch" style={{ margin: 0 }}>
                               <input type="hidden" name="id" value={dnsRecord.id} />


### PR DESCRIPTION
Resolves #389 

### Changes
- Moved renew button closer to expiry date
- Added logic to disable renew button if DNS Record's expiry date is 6 months out or more

<img width="800" alt="image" src="https://user-images.githubusercontent.com/67077705/227430849-62b11fde-5d8d-467f-b9ba-642067d7d9db.png">
