### PR TITLE
Replacing Varchar to Text for 'privateKey' and 'certificate

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -41,9 +41,9 @@ model Certificate {
   username     String
   domain       String
   orderUrl     String?           @unique @db.VarChar(255)
-  privateKey   String?
-  certificate  String?
-  validFrom    DateTime?
+  privateKey   String?           @db.Text
+  certificate  String?           @db.Text
+  validFrom    DateTime?          
   validTo      DateTime?
   lastNotified DateTime?
   status       CertificateStatus @default(pending)


### PR DESCRIPTION
Updates the current type for `privateKey` and `certificate` from `Varchar` -> `Text` to accomodate for a longer string