### PR TITLE
Fix DNS record expiry date always being set to July

### DIFF
--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -58,7 +58,7 @@ export function createDnsRecord(
   data: Pick<DnsRecord, 'username' | 'type' | 'subdomain' | 'value'>
 ) {
   // Set expiration date 6 months from now
-  const expiresAt = dayjs().set('month', 6).toDate();
+  const expiresAt = dayjs().add(6, 'month').toDate();
   const status = DnsRecordStatus.pending;
 
   return prisma.dnsRecord.create({ data: { ...data, expiresAt, status } });
@@ -78,7 +78,7 @@ export function updateDnsRecordById(
       ...data,
       // If the record is changing to the `active` status, update expiry too
       expiresAt:
-        data.status === DnsRecordStatus.active ? dayjs().set('month', 6).toDate() : undefined,
+        data.status === DnsRecordStatus.active ? dayjs().add(6, 'month').toDate() : undefined,
     },
   });
 }
@@ -89,7 +89,8 @@ export function renewDnsRecordById(id: DnsRecord['id']) {
       id,
     },
     data: {
-      expiresAt: dayjs().set('month', 6).toDate(),
+      // Set expiration date 6 months from now
+      expiresAt: dayjs().add(6, 'month').toDate(),
     },
   });
 }


### PR DESCRIPTION
Fixes #281 

Currently, the expiry date for a DNS Record is always set to July. This PR changes this to set it to 6 months from current date instead.

### Steps to test
- Run app locally
- Navigate to Records page
- Create a new record
- Check that expiry date is 6 months from now
- Edit record's expiry date to less than 6 months using prima studio (`npm run db:studio`)
- Click renew button
- Check expiry date is 6 months from now
