### PR TITLE
Allow only alphanumerical and hyphen in record

### DIFF
--- a/app/lib/dns.server.ts
+++ b/app/lib/dns.server.ts
@@ -190,9 +190,9 @@ export const getChangeStatus = async (changeId: string) => {
 
 /* Domain name rules
 1. Full domain name pattern should be [subdomain].[username].rootDomain.com
-2. Subdomain can contain only alphanumerical characters, '-', and '_'
+2. Subdomain can contain only alphanumerical characters and '-'
 3. Subdomain should not start or end with -
-4. Subdomain cannot contain multiple consecutive '-' or '_'
+4. Subdomain cannot contain multiple consecutive '-'
 5. Subdomain can contain uppercase in UI but it is converted to lowercase before validation */
 export const isNameValid = (fqdn: string, username: string) => {
   const baseDomain = buildUserBaseDomain(username);
@@ -211,9 +211,9 @@ export const isNameValid = (fqdn: string, username: string) => {
     return false;
   }
 
-  //It only validates subdomain name, not username and root domain
+  // It only validates subdomain name, not username and root domain
   return (
-    /^(?!.*[-_]{2,})(?!^[-])[a-z0-9_-]+[a-z0-9]$/.test(subdomain) &&
+    /^(?!.*[-]{2,})(?!^[-])[a-z0-9-]+[a-z0-9]$/.test(subdomain) &&
     isFQDN(fqdn, {
       allow_underscores: true,
     })

--- a/test/unit/dns.server.test.ts
+++ b/test/unit/dns.server.test.ts
@@ -32,17 +32,17 @@ describe('DNS server lib function test', () => {
   test('isNameValid() returns true when valid URL is passed. Otherwise it returns false', () => {
     expect(isNameValid(`osd700.${username}.${rootDomain}`, username)).toBe(true);
     expect(isNameValid(`osd-700.${username}.${rootDomain}`, username)).toBe(true);
-    expect(isNameValid(`osd_700.${username}.${rootDomain}`, username)).toBe(true);
-    expect(isNameValid(`_osd700.${username}.${rootDomain}`, username)).toBe(true);
-    expect(isNameValid(`invalid__name.${username}.${rootDomain}`, username)).toBe(false);
+
+    expect(isNameValid(`osd__700.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`osd_700.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`osd700_.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`_osd700.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`-osd700.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`osd700-.${username}.${rootDomain}`, username)).toBe(false);
+    expect(isNameValid(`osd--700.${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`osd700..${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`osd..700.${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`osd700.a2.${username}.${rootDomain}`, username)).toBe(false);
-    expect(isNameValid(`-osd700.${username}.${rootDomain}`, username)).toBe(false);
-    expect(isNameValid(`osd700-.${username}.${rootDomain}`, username)).toBe(false);
-    expect(isNameValid(`osd700_.${username}.${rootDomain}`, username)).toBe(false);
-    expect(isNameValid(`osd--700.${username}.${rootDomain}`, username)).toBe(false);
-    expect(isNameValid(`osd__700.${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`osd@700.${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`damn.${username}.${rootDomain}`, username)).toBe(false);
     expect(isNameValid(`osd-700.localhost`, username)).toBe(false);


### PR DESCRIPTION
Close #437 

- Update regex to allow only alphanumeric characters and `-`
- Record name can't start or end with `-`
- Record name can't have consecutive `-` in the middle