### PR TITLE
Tests for functions that interact with system state

### DIFF
--- a/app/models/system-state.server.ts
+++ b/app/models/system-state.server.ts
@@ -11,7 +11,7 @@ import type { SystemState } from '@prisma/client';
  * to our Records table
  */
 
-function initialize() {
+export function initialize() {
   return prisma.systemState.create({
     data: {
       unique: StateEnumType.unique,

--- a/app/models/system-state.server.ts
+++ b/app/models/system-state.server.ts
@@ -29,7 +29,7 @@ export function getIsReconciliationNeeded(): Promise<SystemState['reconciliation
     .then((data) => data?.reconciliationNeeded ?? true);
 }
 
-export async function setIsReconciliationNeeded(
+export function setIsReconciliationNeeded(
   reconciliationNeeded: SystemState['reconciliationNeeded']
 ) {
   return prisma.systemState

--- a/app/models/system-state.server.ts
+++ b/app/models/system-state.server.ts
@@ -29,11 +29,12 @@ export function getIsReconciliationNeeded(): Promise<SystemState['reconciliation
     .then((data) => data?.reconciliationNeeded ?? true);
 }
 
-export function setIsReconciliationNeeded(
+export async function setIsReconciliationNeeded(
   reconciliationNeeded: SystemState['reconciliationNeeded']
 ) {
+  let result;
   try {
-    return prisma.systemState.update({
+    result = await prisma.systemState.update({
       data: { reconciliationNeeded },
       where: { unique: StateEnumType.unique },
     });
@@ -46,4 +47,5 @@ export function setIsReconciliationNeeded(
 
     return initialize();
   }
+  return result;
 }

--- a/app/models/system-state.server.ts
+++ b/app/models/system-state.server.ts
@@ -32,20 +32,18 @@ export function getIsReconciliationNeeded(): Promise<SystemState['reconciliation
 export async function setIsReconciliationNeeded(
   reconciliationNeeded: SystemState['reconciliationNeeded']
 ) {
-  let result;
-  try {
-    result = await prisma.systemState.update({
+  return prisma.systemState
+    .update({
       data: { reconciliationNeeded },
       where: { unique: StateEnumType.unique },
-    });
-  } catch (error) {
-    /**
-     * This should never happen, as the table should always be seeded.
-     * In case it isn't, let's seed it here Next queue run will set the
-     * correct reconciliationNeeded
-     */
+    })
+    .catch(() => {
+      /**
+       * This should never happen, as the table should always be seeded.
+       * In case it isn't, let's seed it here Next queue run will set the
+       * correct reconciliationNeeded
+       */
 
-    return initialize();
-  }
-  return result;
+      return initialize();
+    });
 }

--- a/test/unit/system-state.server.test.ts
+++ b/test/unit/system-state.server.test.ts
@@ -1,0 +1,79 @@
+import {
+  getIsReconciliationNeeded,
+  initialize,
+  setIsReconciliationNeeded,
+} from '~/models/system-state.server';
+import type { SystemState } from '@prisma/client';
+import { prisma } from '~/db.server';
+
+describe('initialize()', () => {
+  let state: SystemState;
+  beforeAll(async () => {
+    state = await initialize();
+  });
+
+  afterAll(async () => {
+    await prisma.systemState.deleteMany().catch(() => {});
+  });
+
+  test('can create system state', async () => {
+    expect(typeof state).toEqual('object');
+    expect(state.unique).toBe(`unique`);
+    expect(state.reconciliationNeeded).toBe(true);
+  });
+
+  test('only one system state can exist', async () => {
+    await expect(
+      prisma.systemState.create({
+        data: {},
+      })
+    ).rejects.toThrow();
+    await expect(initialize()).rejects.toThrow();
+  });
+});
+
+describe('getIsReconciliationNeeded()', () => {
+  let state: SystemState;
+  beforeAll(async () => {
+    state = await initialize();
+  });
+
+  afterAll(async () => {
+    await prisma.systemState.deleteMany().catch(() => {});
+  });
+
+  test('can get system state correctly', async () => {
+    let result = await getIsReconciliationNeeded();
+    expect(result).toBe(state.reconciliationNeeded);
+  });
+
+  test('can get system state correctly when it does not exist', async () => {
+    await prisma.systemState.deleteMany().catch(() => {});
+    let result = await getIsReconciliationNeeded();
+    expect(result).toBe(true);
+  });
+});
+
+describe('setIsReconciliationNeeded()', () => {
+  beforeAll(async () => {
+    await initialize();
+  });
+
+  afterAll(async () => {
+    await prisma.systemState.deleteMany().catch(() => {});
+  });
+
+  test('can set system state correctly', async () => {
+    await setIsReconciliationNeeded(false);
+    let result = await getIsReconciliationNeeded();
+    expect(result).toBe(false);
+  });
+
+  test('would throw error and initialize when system state does not exist', async () => {
+    await prisma.systemState.deleteMany().catch(() => {});
+    await expect(setIsReconciliationNeeded(false)).rejects.toThrow();
+
+    let result = await getIsReconciliationNeeded();
+    expect(result).toBe(true);
+  });
+});

--- a/test/unit/system-state.server.test.ts
+++ b/test/unit/system-state.server.test.ts
@@ -51,6 +51,9 @@ describe('getIsReconciliationNeeded()', () => {
     await prisma.systemState.deleteMany().catch(() => {});
     let result = await getIsReconciliationNeeded();
     expect(result).toBe(true);
+
+    // Restore state
+    await initialize();
   });
 });
 

--- a/test/unit/system-state.server.test.ts
+++ b/test/unit/system-state.server.test.ts
@@ -51,9 +51,6 @@ describe('getIsReconciliationNeeded()', () => {
     await prisma.systemState.deleteMany().catch(() => {});
     let result = await getIsReconciliationNeeded();
     expect(result).toBe(true);
-
-    // Restore state
-    await initialize();
   });
 });
 

--- a/test/unit/system-state.server.test.ts
+++ b/test/unit/system-state.server.test.ts
@@ -69,11 +69,13 @@ describe('setIsReconciliationNeeded()', () => {
     expect(result).toBe(false);
   });
 
-  test('would throw error and initialize when system state does not exist', async () => {
+  test('would initialize when system state does not exist', async () => {
     await prisma.systemState.deleteMany().catch(() => {});
-    await expect(setIsReconciliationNeeded(false)).rejects.toThrow();
-
-    let result = await getIsReconciliationNeeded();
-    expect(result).toBe(true);
+    await setIsReconciliationNeeded(false);
+    let result = await prisma.systemState.findUnique({
+      select: { reconciliationNeeded: true },
+      where: { unique: `unique` },
+    });
+    expect(result?.reconciliationNeeded).toBe(true);
   });
 });


### PR DESCRIPTION
Closes #482

## Changes
* Add tests for the file `~\models\system-state.server.ts`.
* Adjust `setIsReconciliationNeeded()` to allow `initialize()` to execute, in cases where the system state row doesn't exist in database table `SystemState`. Previously, it instead produces a serialization error and does not execute the function call for `initialize()` in the catch block.

## Test
1. setup test database via `npm run setup:test`
2. run the test file via `npm run test system-state.server.test.ts`