### PR TITLE
Create docker-production.yml similar to docker-staging.yml

### DIFF
--- a/docker-production.yml
+++ b/docker-production.yml
@@ -1,0 +1,65 @@
+# Stack Definition for Production
+services:
+  # Redis is used to back our worker queues. It is not exposed.
+  redis:
+    image: redis:7.0.9-alpine3.17@sha256:8201775852e31262823ac8da9d76d0c8f36583f1a028b4800c35fc319c75289f
+    volumes:
+      - redis-data:/data
+    deploy:
+      placement:
+        # We run the redis instance on the manager node only
+        constraints: [node.role == manager]
+
+  mycustomdomain:
+    # Production runs the most recent release
+    image: ghcr.io/developingspace/starchart:release
+    depends_on:
+      - redis
+    ports:
+      - 8080:8080
+    environment:
+      - APP_URL=https://mycustomdomain.senecacollege.ca
+      - AWS_ROUTE53_HOSTED_ZONE_ID=Z06191131OO53SNFL465G
+      - LETS_ENCRYPT_ACCOUNT_EMAIL=mycustomdomain@senecacollege.ca
+      - LETS_ENCRYPT_DIRECTORY_URL=https://acme-v02.api.letsencrypt.org/directory
+      - LOG_LEVEL=info
+      - NODE_ENV=production
+      - NOTIFICATIONS_EMAIL_USER=mycustomdomain@senecacollege.ca
+      - PORT=8080
+      - REDIS_URL=redis://redis:6379
+      - ROOT_DOMAIN=mystudentproject.ca
+    secrets:
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
+      - DATABASE_URL
+      - LETS_ENCRYPT_ACCOUNT_PRIVATE_KEY_PEM
+      - NOTIFICATIONS_USERNAME
+      - NOTIFICATIONS_PASSWORD
+      - SESSION_SECRET
+    deploy:
+      mode: replicated
+      replicas: 2
+      update_config:
+        # Only update 1 instance at a time, not all at once (rolling-update)
+        parallelism: 1
+        # If the update fails, rollback to last-known-good
+        failure_action: rollback
+
+secrets:
+  AWS_ACCESS_KEY_ID:
+    external: true
+  AWS_SECRET_ACCESS_KEY:
+    external: true
+  DATABASE_URL:
+    external: true
+  LETS_ENCRYPT_ACCOUNT_PRIVATE_KEY_PEM:
+    external: true
+  NOTIFICATIONS_USERNAME:
+    external: true
+  NOTIFICATIONS_PASSWORD:
+    external: true
+  SESSION_SECRET:
+    external: true
+
+volumes:
+  redis-data:


### PR DESCRIPTION
This creates a Docker swarm stack file for production.  It's very similar to staging (by design!) but all the `-dev` stuff has been removed and the hosted zone/root domain are different.

I've also removed the `DATABASE_SETUP=1` bit, since it's not something I want to run accidentally on production.

We won't need this for a few weeks, but I wanted to get it in, now that we have staging finalized and working well.