### PR TITLE
Add checks for deactivated users

### DIFF
--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -4,7 +4,7 @@ import { prisma } from '~/db.server';
 import { setIsReconciliationNeeded } from './system-state.server';
 
 import type { DnsRecord } from '@prisma/client';
-import { isDeactivated } from './user.server';
+import { isUserDeactivated } from './user.server';
 
 export function getDnsRecordsByUsername(username: DnsRecord['username']) {
   return prisma.dnsRecord.findMany({
@@ -37,7 +37,7 @@ export function getUserDnsRecordCount(username: DnsRecord['username']) {
 export async function createDnsRecord(
   data: Required<Pick<DnsRecord, 'username' | 'type' | 'subdomain' | 'value'>> & Partial<DnsRecord>
 ) {
-  if (await isDeactivated(data.username)) {
+  if (await isUserDeactivated(data.username)) {
     throw new Error('User is deactivated');
   }
 

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -76,7 +76,7 @@ export async function isAdmin(username: PrismaUser['username']) {
   return /mycustomdomain(-dev)?-admins/.test(group);
 }
 
-export async function isDeactivated(username: PrismaUser['username']) {
+export async function isUserDeactivated(username: PrismaUser['username']) {
   const user = await prisma.user.findUnique({ where: { username } });
   if (!user) {
     return undefined;

--- a/app/queues/certificate/certificate-flow.server.ts
+++ b/app/queues/certificate/certificate-flow.server.ts
@@ -13,7 +13,7 @@ import { redis } from '~/lib/redis.server';
 
 import type { FlowJob } from 'bullmq';
 import type { CertificateJobData } from './certificateJobTypes.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 
 // Exporting these to allow for graceful shutdown
 export {
@@ -33,7 +33,7 @@ const flowProducer = new FlowProducer({ connection: redis });
 
 export const addCertRequest = async ({ rootDomain, username }: AddCertRequest) => {
   // Don't do anything is user is deactivated
-  if (await isDeactivated(username)) {
+  if (await isUserDeactivated(username)) {
     return;
   }
 

--- a/app/queues/certificate/certificate-flow.server.ts
+++ b/app/queues/certificate/certificate-flow.server.ts
@@ -13,6 +13,7 @@ import { redis } from '~/lib/redis.server';
 
 import type { FlowJob } from 'bullmq';
 import type { CertificateJobData } from './certificateJobTypes.server';
+import { isDeactivated } from '~/models/user.server';
 
 // Exporting these to allow for graceful shutdown
 export {
@@ -31,6 +32,11 @@ interface AddCertRequest {
 const flowProducer = new FlowProducer({ connection: redis });
 
 export const addCertRequest = async ({ rootDomain, username }: AddCertRequest) => {
+  // Don't do anything is user is deactivated
+  if (await isDeactivated(username)) {
+    return;
+  }
+
   /**
    * We are adding 5 jobs, to separate queues, each
    * parent depending on the child to complete

--- a/app/queues/certificate/challenge-completer-worker.server.ts
+++ b/app/queues/certificate/challenge-completer-worker.server.ts
@@ -5,13 +5,19 @@ import LetsEncrypt from '~/lib/lets-encrypt.server';
 import * as certificateModel from '~/models/certificate.server';
 
 import type { CertificateJobData } from './certificateJobTypes.server';
+import { isDeactivated } from '~/models/user.server';
 
 export const challengeCompleterQueueName = 'certificate-completeChallenges';
 
 export const challengeCompleterWorker = new Worker<CertificateJobData>(
   challengeCompleterQueueName,
   async (job) => {
-    const { rootDomain, certificateId } = job.data;
+    const { rootDomain, username, certificateId } = job.data;
+
+    if (await isDeactivated(username)) {
+      logger.error('User is deactivated, skipping challenge completion');
+      throw new UnrecoverableError('User is deactivated');
+    }
 
     logger.info('Attempting to complete ACME challenges with the provider', {
       rootDomain,

--- a/app/queues/certificate/challenge-completer-worker.server.ts
+++ b/app/queues/certificate/challenge-completer-worker.server.ts
@@ -5,7 +5,7 @@ import LetsEncrypt from '~/lib/lets-encrypt.server';
 import * as certificateModel from '~/models/certificate.server';
 
 import type { CertificateJobData } from './certificateJobTypes.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 
 export const challengeCompleterQueueName = 'certificate-completeChallenges';
 
@@ -14,7 +14,7 @@ export const challengeCompleterWorker = new Worker<CertificateJobData>(
   async (job) => {
     const { rootDomain, username, certificateId } = job.data;
 
-    if (await isDeactivated(username)) {
+    if (await isUserDeactivated(username)) {
       logger.error('User is deactivated, skipping challenge completion');
       throw new UnrecoverableError('User is deactivated');
     }

--- a/app/queues/certificate/dns-waiter-worker.server.ts
+++ b/app/queues/certificate/dns-waiter-worker.server.ts
@@ -5,7 +5,7 @@ import LetsEncrypt from '~/lib/lets-encrypt.server';
 import * as challengeModel from '~/models/challenge.server';
 
 import type { CertificateJobData } from './certificateJobTypes.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 
 export const dnsWaiterQueueName = 'certificate-waitDns';
 
@@ -28,7 +28,7 @@ export const dnsWaiterWorker = new Worker<CertificateJobData>(
       return;
     }
 
-    if (await isDeactivated(username)) {
+    if (await isUserDeactivated(username)) {
       logger.error('User is deactivated, skipping checking challenges');
       throw new UnrecoverableError('User is deactivated');
     }

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -6,7 +6,7 @@ import LetsEncrypt from '~/lib/lets-encrypt.server';
 import * as certificateModel from '~/models/certificate.server';
 
 import type { CertificateJobData } from './certificateJobTypes.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 
 export const orderCompleterQueueName = 'certificate-completeOrder';
 
@@ -15,7 +15,7 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
   async (job) => {
     const { rootDomain, username, certificateId } = job.data;
 
-    if (await isDeactivated(username)) {
+    if (await isUserDeactivated(username)) {
       logger.error('User is deactivated, skipping order completion');
       throw new UnrecoverableError('User is deactivated');
     }

--- a/app/queues/certificate/order-creator-worker.server.ts
+++ b/app/queues/certificate/order-creator-worker.server.ts
@@ -9,6 +9,7 @@ import { getSubdomainFromFqdn } from '~/utils';
 
 import type { ChallengeBundle } from '~/lib/lets-encrypt.server';
 import type { CertificateJobData } from './certificateJobTypes.server';
+import { isDeactivated } from '~/models/user.server';
 
 export const orderCreatorQueueName = 'certificate-createOrder';
 
@@ -78,6 +79,11 @@ export const orderCreatorWorker = new Worker<CertificateJobData>(
   orderCreatorQueueName,
   async (job) => {
     const { rootDomain, username, certificateId } = job.data;
+
+    if (await isDeactivated(username)) {
+      logger.error('User is deactivated, skipping order creation');
+      throw new UnrecoverableError('User is deactivated');
+    }
 
     logger.info(`Creating certificate order for ${rootDomain}`);
 

--- a/app/queues/certificate/order-creator-worker.server.ts
+++ b/app/queues/certificate/order-creator-worker.server.ts
@@ -9,7 +9,7 @@ import { getSubdomainFromFqdn } from '~/utils';
 
 import type { ChallengeBundle } from '~/lib/lets-encrypt.server';
 import type { CertificateJobData } from './certificateJobTypes.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 
 export const orderCreatorQueueName = 'certificate-createOrder';
 
@@ -80,7 +80,7 @@ export const orderCreatorWorker = new Worker<CertificateJobData>(
   async (job) => {
     const { rootDomain, username, certificateId } = job.data;
 
-    if (await isDeactivated(username)) {
+    if (await isUserDeactivated(username)) {
       logger.error('User is deactivated, skipping order creation');
       throw new UnrecoverableError('User is deactivated');
     }

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -36,7 +36,7 @@ export async function getUsername(request: Request): Promise<User['username'] | 
   const username = session.get(USER_SESSION_KEY);
 
   // Logout user if they are deactivated
-  if (await isUserDeactivated(username)) {
+  if (username && (await isUserDeactivated(username))) {
     throw await logout(request);
   }
 

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,6 +1,7 @@
 import { createCookie, createCookieSessionStorage, redirect } from '@remix-run/node';
 
 import type { User } from '~/models/user.server';
+import { isDeactivated } from '~/models/user.server';
 import { getUserByUsername } from '~/models/user.server';
 import secrets from '~/lib/secrets.server';
 
@@ -55,7 +56,7 @@ export async function requireUsername(
   redirectTo: string = new URL(request.url).pathname
 ) {
   const username = await getUsername(request);
-  if (!username) {
+  if (!username || (await isDeactivated(username))) {
     const searchParams = new URLSearchParams([['redirectTo', redirectTo]]);
     throw redirect(`/login?${searchParams}`);
   }

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -56,10 +56,16 @@ export async function requireUsername(
   redirectTo: string = new URL(request.url).pathname
 ) {
   const username = await getUsername(request);
-  if (!username || (await isDeactivated(username))) {
+  if (!username) {
     const searchParams = new URLSearchParams([['redirectTo', redirectTo]]);
     throw redirect(`/login?${searchParams}`);
   }
+
+  // Logout user if they are deactivated
+  if (await isDeactivated(username)) {
+    throw await logout(request);
+  }
+
   return username;
 }
 

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -34,6 +34,12 @@ export async function getSession(request: Request) {
 export async function getUsername(request: Request): Promise<User['username'] | undefined> {
   const session = await getSession(request);
   const username = session.get(USER_SESSION_KEY);
+
+  // Logout user if they are deactivated
+  if (await isDeactivated(username)) {
+    throw await logout(request);
+  }
+
   return username;
 }
 
@@ -59,11 +65,6 @@ export async function requireUsername(
   if (!username) {
     const searchParams = new URLSearchParams([['redirectTo', redirectTo]]);
     throw redirect(`/login?${searchParams}`);
-  }
-
-  // Logout user if they are deactivated
-  if (await isDeactivated(username)) {
-    throw await logout(request);
   }
 
   return username;

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,7 +1,7 @@
 import { createCookie, createCookieSessionStorage, redirect } from '@remix-run/node';
 
 import type { User } from '~/models/user.server';
-import { isDeactivated } from '~/models/user.server';
+import { isUserDeactivated } from '~/models/user.server';
 import { getUserByUsername } from '~/models/user.server';
 import secrets from '~/lib/secrets.server';
 
@@ -36,7 +36,7 @@ export async function getUsername(request: Request): Promise<User['username'] | 
   const username = session.get(USER_SESSION_KEY);
 
   // Logout user if they are deactivated
-  if (await isDeactivated(username)) {
+  if (await isUserDeactivated(username)) {
     throw await logout(request);
   }
 

--- a/test/unit/user.server.test.ts
+++ b/test/unit/user.server.test.ts
@@ -3,7 +3,7 @@ import {
   checkUsernameExists,
   deactivateUserByUsername,
   deleteUserByUsername,
-  isDeactivated,
+  isUserDeactivated,
   getUserByUsername,
   isStudent,
   isAdmin,
@@ -85,7 +85,7 @@ describe('deleteUserByUsername()', () => {
   });
 });
 
-describe('isDeactivated()', () => {
+describe('isUserDeactivated()', () => {
   let activeUser: User;
   let deactivatedUser: User;
 
@@ -100,17 +100,17 @@ describe('isDeactivated()', () => {
   });
 
   test('returns true for deactivated user', async () => {
-    const result = await isDeactivated(deactivatedUser.username);
+    const result = await isUserDeactivated(deactivatedUser.username);
     expect(result).toBe(true);
   });
 
   test('returns false for active user', async () => {
-    const result = await isDeactivated(activeUser.username);
+    const result = await isUserDeactivated(activeUser.username);
     expect(result).toBe(false);
   });
 
   test('returns undefined when no user is found', async () => {
-    const result = await isDeactivated('invalid username');
+    const result = await isUserDeactivated('invalid username');
     expect(result).toBe(undefined);
   });
 });


### PR DESCRIPTION
Resolves #394, resolves #308 

This PR updates the `requireUsername` (and therefore also `requireUser`) function to logout the user if the user is deactivated. 
This in turn ensures that no actions can be performed on routes where we use these functions as the user will be immediately logged out, and redirected to the login page.
It also updates the certificate workers to throw an unrecoverable error if the user is deactivated

