### PR TITLE
FE: Fixing the style of certificate text

### DIFF
--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -94,7 +94,14 @@ export default function CertificateDisplay({ title, description, value }: Certif
           </AccordionButton>
           <AccordionPanel>
             <Flex justifyContent="center">
-              <Text maxWidth={{ base: '3xs', xs: 'xs', sm: 'md', md: 'full' }}>{value}</Text>
+              <Text
+                fontFamily="mono"
+                maxWidth={{ base: '2xs', xs: 'xs', sm: 'md', md: 'full' }}
+                fontSize={{ base: '3xs', sm: 'xs', md: 'md' }}
+                css={{ whiteSpace: 'pre-line' }}
+              >
+                {value}
+              </Text>
             </Flex>
           </AccordionPanel>
         </AccordionItem>


### PR DESCRIPTION
Should fix the issue with certificate not having the correct format when displayed

![image](https://user-images.githubusercontent.com/32577022/229134971-d1073b9f-d617-453e-a481-bd566c401711.png)
