### PR TITLE
Bug: fix issue with pending page not displaying

### DIFF
--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -11,7 +11,7 @@ export async function getCertificateByUsername(username: Certificate['username']
    */
   return prisma.certificate
     .findMany({
-      where: { username, status: 'issued' },
+      where: { username },
       orderBy: { validFrom: 'desc' },
       take: 1,
     })


### PR DESCRIPTION
Fixes #494 

`getCertificateByUsername` only returns status that are `issued`, I reverted it back to its previous state of returning any certificate regardless of the status which should fix the issue with pending page not showing