### PR TITLE
Remove Admin table role, add icons for cert status

### DIFF
--- a/app/components/admin/certificate-status-icon.tsx
+++ b/app/components/admin/certificate-status-icon.tsx
@@ -1,0 +1,33 @@
+import { Icon, Text } from '@chakra-ui/react';
+import { GrCertificate, GrDocumentTime, GrDocumentMissing } from 'react-icons/gr';
+
+import { CertificateStatus } from '@prisma/client';
+
+interface CertificateStatusIconProps {
+  status?: CertificateStatus;
+}
+
+export default function CertificateStatusIcon({ status }: CertificateStatusIconProps) {
+  switch (status) {
+    case CertificateStatus.failed:
+      return (
+        <Text display="flex" title="Certificate failed">
+          <Icon as={GrDocumentMissing} boxSize="1.3em" marginRight="16px" /> Failed
+        </Text>
+      );
+    case CertificateStatus.issued:
+      return (
+        <Text display="flex" title="Certificate issued">
+          <Icon as={GrCertificate} boxSize="1.3em" marginRight="16px" /> Issued
+        </Text>
+      );
+    case CertificateStatus.pending:
+      return (
+        <Text display="flex" title="Certificate pending...">
+          <Icon as={GrDocumentTime} boxSize="1.3em" marginRight="16px" /> Pending...
+        </Text>
+      );
+    default:
+      return null;
+  }
+}

--- a/app/components/admin/users-table.tsx
+++ b/app/components/admin/users-table.tsx
@@ -17,9 +17,12 @@ import {
 } from '@chakra-ui/react';
 import { CopyIcon, DeleteIcon } from '@chakra-ui/icons';
 import { FaTheaterMasks } from 'react-icons/fa';
+import { useNavigation } from '@remix-run/react';
+
 import type { UserWithMetrics } from '~/routes/__index/admin';
 import { MIN_USERS_SEARCH_TEXT } from '~/routes/__index/admin';
-import { useNavigation } from '@remix-run/react';
+
+import CertificateStatusIcon from '~/components/admin/certificate-status-icon';
 
 interface UsersTableProps {
   users: UserWithMetrics[];
@@ -56,7 +59,6 @@ export default function UsersTable({ users, searchText }: UsersTableProps) {
               <Th>Name</Th>
               <Th>DNS Records</Th>
               <Th>Certificate status</Th>
-              <Th>Role</Th>
               <Th />
             </Tr>
           </Thead>
@@ -95,8 +97,9 @@ export default function UsersTable({ users, searchText }: UsersTableProps) {
                     </Td>
                     <Td>{user.displayName}</Td>
                     <Td>{user.dnsRecordCount}</Td>
-                    <Td>{user.certificate ? user.certificate.status : 'Not issued'}</Td>
-                    <Td>{user.group}</Td>
+                    <Td>
+                      <CertificateStatusIcon status={user.certificate?.status} />
+                    </Td>
                     <Td>
                       <HStack>
                         <Tooltip label="Impersonate user">


### PR DESCRIPTION
This makes the Admin table a bit easer to use by:

1. Removing the user's role (it's too wide, doesn't provide any useful details)
2. Adding icons to the Certificate Status

<img width="1155" alt="Screenshot 2023-04-02 at 11 56 03 AM" src="https://user-images.githubusercontent.com/427398/229364321-ad7f960c-b32f-486f-a974-ab44393a5712.png">

Fixes #473