### PR TITLE
Make DNS Record form text more helpful

### DIFF
--- a/app/components/dns-record/form-field.tsx
+++ b/app/components/dns-record/form-field.tsx
@@ -1,17 +1,25 @@
-import { FormControl, FormErrorMessage, FormLabel, HStack } from '@chakra-ui/react';
+import { FormControl, FormErrorMessage, FormHelperText, FormLabel, HStack } from '@chakra-ui/react';
 
 interface FormFieldProps {
   label: string;
   isRequired?: boolean;
   error?: string;
+  helpText?: string;
   children: React.ReactNode;
 }
 
-export default function FormField({ label, isRequired, error, children }: FormFieldProps) {
+export default function FormField({
+  label,
+  isRequired,
+  error,
+  helpText,
+  children,
+}: FormFieldProps) {
   return (
     <FormControl isRequired={isRequired} isInvalid={!!error}>
       <FormLabel>{label}</FormLabel>
       <HStack w="full">{children}</HStack>
+      {helpText && <FormHelperText fontSize="xs">{helpText}</FormHelperText>}
       <FormErrorMessage>{error}</FormErrorMessage>
     </FormControl>
   );

--- a/app/components/dns-record/form.tsx
+++ b/app/components/dns-record/form.tsx
@@ -1,4 +1,4 @@
-import { AddIcon, InfoIcon, EditIcon } from '@chakra-ui/icons';
+import { AddIcon, EditIcon } from '@chakra-ui/icons';
 import {
   Button,
   Input,
@@ -6,7 +6,6 @@ import {
   InputRightAddon,
   Select,
   Textarea,
-  Tooltip,
   VStack,
 } from '@chakra-ui/react';
 import { Form } from '@remix-run/react';
@@ -32,52 +31,56 @@ export default function DnsRecordForm({ dnsRecord, mode, errors }: dnsRecordForm
 
   return (
     <Form className="dns-record-form" method="post">
-      <VStack maxW="xl" spacing="2">
+      <VStack maxW="xl" spacing="6">
         <FormField
-          label="DNS Record Name"
+          label="Name"
           isRequired={true}
           error={errors?.fieldErrors.subdomain?.join(' ')}
+          helpText="DNS Record Names can contain lowercase letters (a-z), numbers (0-9), and - or _"
         >
           <InputGroup>
             <Input name="subdomain" defaultValue={dnsRecord?.subdomain} />
             <InputRightAddon children={`.${user.baseDomain}`} />
           </InputGroup>
-          <Tooltip label="Enter a name for the DNS Record: name">
-            <InfoIcon color="#d9d9d9" fontSize="xl" />
-          </Tooltip>
         </FormField>
 
-        <FormField label="Type" isRequired={true} error={errors?.fieldErrors.type?.join(' ')}>
+        <FormField
+          label="Type"
+          isRequired={true}
+          helpText="DNS Record Type (IPv4, IPv6, Domain Name, Text) indicates what Value will be"
+          error={errors?.fieldErrors.type?.join(' ')}
+        >
           <Select placeholder="Select a type" name="type" defaultValue={dnsRecord?.type}>
-            <option value="A">A</option>
-            <option value="AAAA">AAAA</option>
-            <option value="CNAME">CNAME</option>
-            <option value="TXT">TXT</option>
+            <option value="A">A Record (IPv4 Address)</option>
+            <option value="AAAA">AAAA Record (IPv6 Address)</option>
+            <option value="CNAME">CNAME Record (Domain Name)</option>
+            <option value="TXT">TXT Record (Text Value)</option>
           </Select>
-          <Tooltip label="Select DNS Record type">
-            <InfoIcon />
-          </Tooltip>
         </FormField>
 
-        <FormField label="Value" isRequired={true} error={errors?.fieldErrors.value?.join(' ')}>
+        <FormField
+          label="Value"
+          isRequired={true}
+          helpText="Value must match Type: A=IPv4, AAAA=IPv6, CNAME=domain.com, TXT=any text..."
+          error={errors?.fieldErrors.value?.join(' ')}
+        >
           <Input name="value" defaultValue={dnsRecord?.value} />
-          <Tooltip label="Enter DNS Record value">
-            <InfoIcon />
-          </Tooltip>
         </FormField>
 
-        <FormField label="Ports" error={errors?.fieldErrors.ports?.join(' ')}>
+        <FormField
+          label="Ports"
+          helpText="Enter one or more Ports in use, separated by comma (e.g., 8080, 1234)"
+          error={errors?.fieldErrors.ports?.join(' ')}
+        >
           <Input name="ports" defaultValue={dnsRecord?.ports ?? ''} />
-          <Tooltip label="Enter port(s) separated by commas (E.g. 8080, 1234)">
-            <InfoIcon />
-          </Tooltip>
         </FormField>
 
-        <FormField label="Course" error={errors?.fieldErrors.course?.join(' ')}>
+        <FormField
+          label="Course"
+          helpText="Course name using this DNS Record (e.g., OSD700)"
+          error={errors?.fieldErrors.course?.join(' ')}
+        >
           <Input name="course" defaultValue={dnsRecord?.course ?? ''} />
-          <Tooltip label="Enter course name (E.g. OSD700)">
-            <InfoIcon />
-          </Tooltip>
         </FormField>
 
         <FormField label="Description" error={errors?.fieldErrors.description?.join(' ')}>

--- a/app/theme/index.ts
+++ b/app/theme/index.ts
@@ -6,17 +6,6 @@ const theme = extendTheme(
   {
     colors,
     breakpoints,
-    styles: {
-      global: {
-        '.dns-record-form': {
-          // InfoIcon
-          '.chakra-icon': {
-            color: colors.brand_gray[300],
-            fontSize: 'xl',
-          },
-        },
-      },
-    },
   },
   withDefaultColorScheme({ colorScheme: 'brand' })
 );

--- a/test/e2e/new-dns-record.spec.ts
+++ b/test/e2e/new-dns-record.spec.ts
@@ -17,7 +17,7 @@ test.describe('authenticated as user', () => {
   });
 
   test('redirects to edit DNS record page when required fields are filled', async ({ page }) => {
-    await page.getByLabel('DNS Record Name*').fill('test');
+    await page.getByLabel('Name*').fill('test');
     await page.getByRole('combobox', { name: 'Type' }).selectOption('A');
     await page.getByLabel('Value*').fill('test');
     await page.getByRole('button', { name: 'Create' }).click();
@@ -25,7 +25,7 @@ test.describe('authenticated as user', () => {
   });
 
   test('redirects to edit DNS record page when all fields are filled', async ({ page }) => {
-    await page.getByLabel('DNS Record Name*').fill('test');
+    await page.getByLabel('Name*').fill('test');
     await page.getByRole('combobox', { name: 'Type' }).selectOption('A');
     await page.getByLabel('Value*').fill('test');
     await page.getByLabel('Ports').fill('port1, port2');


### PR DESCRIPTION
In anticipation of having people do user testing on the app, I've added some more instructions/help text to the DNS Record form:

<img width="549" alt="Screenshot 2023-04-03 at 9 12 01 AM" src="https://user-images.githubusercontent.com/427398/229520180-f187b3ad-a659-4b8c-b591-631f41e96734.png">
<img width="627" alt="Screenshot 2023-04-03 at 9 14 03 AM" src="https://user-images.githubusercontent.com/427398/229520304-9a3baef3-5036-4867-8846-f71851ae3ba0.png">


Let me know if you think I can further improve these messages