### PR TITLE
Use journald log driver, update DEPLOY docs on logging

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -117,10 +117,19 @@ To stop and remove the serivce:
 docker stack rm starchart
 ```
 
-You can then view logs for any of the services by name (e.g., `mycustomdomain`):
+You can then view logs for any of the services by name (e.g., `mycustomdomain` container inside the `starchart` service):
 
 ```sh
 docker service logs --follow starchart_mycustomdomain
+```
+
+The logs are handled by the [journald](https://docs.docker.com/config/containers/logging/journald/) log driver. They can also be accessed via `journalctl`:
+
+```sh
+# See logs for mycustomdomain container(s)
+sudo journalctl -b CONTAINER_TAG=mycustomdomain
+# See logs for redis container
+sudo journalctl -b CONTAINER_TAG=redis
 ```
 
 To see the status of a service across all nodes in the swarm:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
       MYSQL_ROOT_PASSWORD: root_password
 
   redis:
-    image: redis:7.0.8-alpine3.17
+    image: redis:7.0.10-alpine3.17@sha256:221f7fa5b4c563971358755893263d64b0b52e9798f6320f2898be499fb3b6b6
     container_name: redis
     command: ['redis-server']
     ports:

--- a/docker-production.yml
+++ b/docker-production.yml
@@ -2,13 +2,19 @@
 services:
   # Redis is used to back our worker queues. It is not exposed.
   redis:
-    image: redis:7.0.9-alpine3.17@sha256:8201775852e31262823ac8da9d76d0c8f36583f1a028b4800c35fc319c75289f
+    image: redis:7.0.10-alpine3.17@sha256:221f7fa5b4c563971358755893263d64b0b52e9798f6320f2898be499fb3b6b6
     volumes:
       - redis-data:/data
     deploy:
       placement:
         # We run the redis instance on the manager node only
         constraints: [node.role == manager]
+    logging:
+      # Use journald log driver, see:
+      # https://docs.docker.com/config/containers/logging/journald/
+      driver: journald
+      options:
+        tag: redis
 
   mycustomdomain:
     # Production runs the most recent release
@@ -44,6 +50,12 @@ services:
         parallelism: 1
         # If the update fails, rollback to last-known-good
         failure_action: rollback
+    logging:
+      # Use journald log driver, see:
+      # https://docs.docker.com/config/containers/logging/journald/
+      driver: journald
+      options:
+        tag: mycustomdomain
 
 secrets:
   AWS_ACCESS_KEY_ID:

--- a/docker-staging.yml
+++ b/docker-staging.yml
@@ -2,13 +2,19 @@
 services:
   # Redis is used to back our worker queues. It is not exposed.
   redis:
-    image: redis:7.0.9-alpine3.17@sha256:8201775852e31262823ac8da9d76d0c8f36583f1a028b4800c35fc319c75289f
+    image: redis:7.0.10-alpine3.17@sha256:221f7fa5b4c563971358755893263d64b0b52e9798f6320f2898be499fb3b6b6
     volumes:
       - redis-data:/data
     deploy:
       placement:
         # We run the redis instance on the manager node only
         constraints: [node.role == manager]
+    logging:
+      # Use journald log driver, see:
+      # https://docs.docker.com/config/containers/logging/journald/
+      driver: journald
+      options:
+        tag: redis
 
   mycustomdomain:
     # Staging runs the most recent commit on the main branch
@@ -46,6 +52,12 @@ services:
         parallelism: 1
         # If the update fails, rollback to last-known-good
         failure_action: rollback
+    logging:
+      # Use journald log driver, see:
+      # https://docs.docker.com/config/containers/logging/journald/
+      driver: journald
+      options:
+        tag: mycustomdomain
 
 secrets:
   AWS_ACCESS_KEY_ID:


### PR DESCRIPTION
Fixes #117 

This switches Docker to use the `journald` log driver instead of the default `json-file` log driver, see https://docs.docker.com/config/containers/logging/journald/.  Doing so means that the OS (RHEL8) will take care of our log files/rotation for us.

I've also updated the docs to show how to use this.  You can get logs via `docker` or `journalctl`.

This is running on staging, where I've confirmed that it's working.  In order to check both Redis and MyCustomDomain, I had to recreate the containers.  Updating Redis to a new version is the easiest way, and also takes care of doing the update at the same time.