### PR TITLE
Improve landing page responsiveness

### DIFF
--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -21,13 +21,11 @@ export default function IndexRoute() {
         paddingY={{ base: '2', md: '7' }}
         gap={{ md: '16' }}
       >
-        <Flex textAlign="center" padding="5">
-          <Text fontSize={{ base: 'sm', md: 'lg' }}>
-            Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
-            has been the industry's standard dummy text ever since the 1500s, when an unknown
-            printer took a galley of type and scrambled it to make a type specimen book.
-          </Text>
-        </Flex>
+        <Text fontSize={{ base: 'sm', md: 'lg' }} textAlign="center" padding="5">
+          Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum has
+          been the industry's standard dummy text ever since the 1500s, when an unknown printer took
+          a galley of type and scrambled it to make a type specimen book.
+        </Text>
       </Flex>
       <Flex
         flexDirection={{ base: 'column', md: 'row' }}

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -35,7 +35,7 @@ export default function IndexRoute() {
         paddingY="10"
         paddingX={{ base: '10', md: '5' }}
         gap={{ base: '5', lg: '10' }}
-        width={{ base: 'full', sm: '75%' }}
+        width={{ base: 'full', sm: 'lg' }}
       >
         <LandingPageCard
           path="/dns-records"

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -17,11 +17,11 @@ export default function IndexRoute() {
       <Flex
         flexDirection="column"
         alignItems="center"
-        width="100%"
+        width={{ base: 'full', sm: '80%' }}
         paddingY={{ base: '2', md: '7' }}
         gap={{ md: '16' }}
       >
-        <Flex width={{ base: '100%', md: '50%' }} textAlign="center" padding="5">
+        <Flex textAlign="center" padding="5">
           <Text fontSize={{ base: 'sm', md: 'lg' }}>
             Lorem Ipsum is simply dummy text of the printing and typesetting industry. Lorem Ipsum
             has been the industry's standard dummy text ever since the 1500s, when an unknown
@@ -30,11 +30,12 @@ export default function IndexRoute() {
         </Flex>
       </Flex>
       <Flex
-        flexDirection={{ base: 'column', sm: 'row' }}
+        flexDirection={{ base: 'column', md: 'row' }}
         justifyContent="center"
         paddingY="10"
         paddingX={{ base: '10', md: '5' }}
         gap={{ base: '5', lg: '10' }}
+        width={{ base: 'full', sm: '75%' }}
       >
         <LandingPageCard
           path="/dns-records"

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -33,7 +33,7 @@ export default function IndexRoute() {
         paddingY="10"
         paddingX={{ base: '10', md: '5' }}
         gap={{ base: '5', lg: '10' }}
-        width={{ base: 'full', sm: 'lg' }}
+        width={{ base: 'full', sm: 'md' }}
       >
         <LandingPageCard
           path="/dns-records"


### PR DESCRIPTION
Resolves #496

### Changes made
- Made DNS Records and Certificate cards get rendered using a `flex-direction` of `column` until the `md` (768px - Chakra UI default) breakpoint is reached. Essentially the cards will show vertically stacked instead of horizontally up to a bigger screen size than before. Thanks @Ririio for the suggestion
- Removed redundant Flex component for heading
- Updated the width of the heading to be 80% on `sm` (480px - Chakra UI default) breakpoint and up. The heading's width was too small compared to the cards.
- Added a width to the cards container so that they don't stretch to fit the page before the `md` breakpoint

### Before and After Screenshots
<details>
  <summary>2XL screen size (width >= 1536px)</summary>
  
  #### Before
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229977208-e0d2ba94-e517-44bd-a1d6-6b4f56ef530c.png">

  #### After
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229977020-c51d6803-96de-4f02-bfa8-6d577725dc6d.png">
</details>

<details>
  <summary>Extra Large screen size (width < 1536px)</summary>
  
  #### Before
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229977137-f048f648-25b5-4434-b75f-3a6c03ae41f0.png">

  #### After
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229977162-475da778-9512-4f62-8655-f48911d5e779.png">
</details>

<details>
  <summary>Large screen size (width < 1280px)</summary>
  
  #### Before
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229978028-c2fda6e4-85f0-4bee-a469-ca9159c73c33.png">

  #### After
<img width="952" alt="image" src="https://user-images.githubusercontent.com/67077705/229977307-9139ffc8-b852-42a8-b050-0a2f5ee87ad7.png">
</details>

<details>
  <summary>Medium screen size (width < 992px)</summary>
  
  #### Before
<img width="810" alt="image" src="https://user-images.githubusercontent.com/67077705/229977365-da54198e-b729-45e0-95ae-7ac55f6aa6b8.png">

  #### After
<img width="810" alt="image" src="https://user-images.githubusercontent.com/67077705/229977450-111db55b-f96f-4545-a666-c9c2a75455bb.png">
</details>

<details>
  <summary>Small screen size (width < 768px)</summary>
  
  #### Before and After
<img width="350" alt="image" src="https://user-images.githubusercontent.com/67077705/229980856-11264124-7978-496c-bc6e-bbf72d0d4716.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/67077705/229980883-3aa5467c-0b79-41c2-b570-b4d997cc950a.png">

</details>

<details>
  <summary>Extra small screen size (width < 480px) - no change</summary>
  
  #### Before and After (no change)
<img width="350" alt="image" src="https://user-images.githubusercontent.com/67077705/229977766-a6270ec1-d93c-4821-8043-e39d54ba39bb.png">
<img width="350" alt="image" src="https://user-images.githubusercontent.com/67077705/229977789-ec0f60dd-4baf-47eb-bc1b-3ae22d52d627.png">


</details>

### Steps to Test
- Run app locally
- Navigate to landing page
- Open developer tools and using the `toggle device emulation`, adjust the width and height to check for responsiveness