### PR TITLE
Connect Admin UI to landing page

### DIFF
--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -1,4 +1,13 @@
-import { Button, Flex, Heading, Text, VStack } from '@chakra-ui/react';
+import {
+  Button,
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Flex,
+  Heading,
+  Text,
+} from '@chakra-ui/react';
 import { Link } from '@remix-run/react';
 
 interface LandingPageCardProps {
@@ -17,34 +26,31 @@ export default function LandingPageCard({
   instructionsPath,
 }: LandingPageCardProps) {
   return (
-    <VStack
-      height={{ base: 'xs', md: 'sm' }}
-      borderRadius="xl"
-      padding="5"
-      backgroundColor="whitesmoke"
-    >
-      <Heading size={{ base: 'md', md: 'lg' }} color="brand.500" height="100%">
-        {cardName}
-      </Heading>
-
-      <Flex width={{ md: 'xs' }} height={{ sm: 'xl' }} flexDirection="column" gap="4">
-        <Text fontSize={{ base: 'xs', md: 'md' }}>{cardDescription}</Text>
-        {instructionsPath && (
-          <Text>
-            To learn more, see{' '}
-            <Text as={Link} to={instructionsPath} color="brand.500" textDecor="underline">
-              these instructions
+    <Card variant="filled" backgroundColor="whitesmoke" maxWidth="sm" align="center">
+      <CardHeader>
+        <Heading as="h2" size="lg" color="brand.500" height="100%">
+          {cardName}
+        </Heading>
+      </CardHeader>
+      <CardBody>
+        <Flex direction="column" gap={4}>
+          <Text>{cardDescription}</Text>
+          {instructionsPath && (
+            <Text>
+              To learn more, see{' '}
+              <Text as={Link} to={instructionsPath} color="brand.500" textDecor="underline">
+                these instructions
+              </Text>
+              .
             </Text>
-            .
-          </Text>
-        )}
-      </Flex>
-
-      <Flex width="100%" justifyContent="center" height="100%" alignItems="flex-end">
+          )}
+        </Flex>
+      </CardBody>
+      <CardFooter>
         <Button as={Link} to={{ pathname: path }} size={{ base: 'xs', xs: 'sm', md: 'md' }}>
           {pathName}
         </Button>
-      </Flex>
-    </VStack>
+      </CardFooter>
+    </Card>
   );
 }

--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -6,6 +6,7 @@ interface LandingPageCardProps {
   pathName: string;
   cardName: string;
   cardDescription: string;
+  instructionsPath?: string;
 }
 
 export default function LandingPageCard({
@@ -13,6 +14,7 @@ export default function LandingPageCard({
   pathName,
   cardName,
   cardDescription,
+  instructionsPath,
 }: LandingPageCardProps) {
   return (
     <VStack
@@ -25,14 +27,17 @@ export default function LandingPageCard({
         {cardName}
       </Heading>
 
-      <Flex width={{ md: 'xs' }} height={{ sm: 'xl' }} flexDirection="column">
-        <Text fontSize={{ base: 'xs', md: 'md' }}>
-          {cardDescription}
-          <br />
-          <Text as={Link} to={`${path}/instructions`} color="brand.500" textDecor="underline">
-            To learn more, see these instructions...
+      <Flex width={{ md: 'xs' }} height={{ sm: 'xl' }} flexDirection="column" gap="4">
+        <Text fontSize={{ base: 'xs', md: 'md' }}>{cardDescription}</Text>
+        {instructionsPath && (
+          <Text>
+            To learn more, see{' '}
+            <Text as={Link} to={instructionsPath} color="brand.500" textDecor="underline">
+              these instructions
+            </Text>
+            .
           </Text>
-        </Text>
+        )}
       </Flex>
 
       <Flex width="100%" justifyContent="center" height="100%" alignItems="flex-end">

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -19,12 +19,7 @@ export default function IndexRoute() {
         paddingY={{ base: '2', md: '7' }}
         gap={{ md: '16' }}
       >
-        <Flex
-          width={{ base: '100%', md: '3xl' }}
-          maxWidth="42em"
-          padding="5"
-          flexDirection="column"
-        >
+        <Flex width={{ base: '100%', md: '3xl' }} padding="5" flexDirection="column">
           <Heading size="lg" textAlign="center">
             Welcome to My.Custom.Domain!
           </Heading>

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -20,7 +20,7 @@ export default function IndexRoute() {
         gap={{ md: '16' }}
       >
         <Flex
-          width={{ base: '100%', md: '75%' }}
+          width={{ base: '100%', md: '3xl' }}
           maxWidth="42em"
           padding="5"
           flexDirection="column"

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -1,17 +1,15 @@
 import { Flex, Text, VStack, Link, Heading } from '@chakra-ui/react';
 import type { LoaderArgs } from '@remix-run/node';
-import { json } from '@remix-run/node';
 
 import { requireUsername } from '~/session.server';
 import LandingPageCard from '~/components/landing-page/landing-page-card';
+import { useUser } from '~/utils';
 
-export const loader = async ({ request }: LoaderArgs) => {
-  const username = await requireUsername(request);
-
-  return json({ username });
-};
+export const loader = async ({ request }: LoaderArgs) => requireUsername(request);
 
 export default function IndexRoute() {
+  const user = useUser();
+
   return (
     <VStack alignSelf="center">
       <Flex
@@ -23,11 +21,13 @@ export default function IndexRoute() {
       >
         <Flex
           width={{ base: '100%', md: '75%' }}
-          textAlign="center"
+          maxWidth="42em"
           padding="5"
           flexDirection="column"
         >
-          <Heading size="lg">Welcome to My.Custom.Domain!</Heading>
+          <Heading size="lg" textAlign="center">
+            Welcome to My.Custom.Domain!
+          </Heading>
           <Text fontSize={{ base: 'sm', md: 'lg' }} mt={4}>
             My.Custom.Domain allows you to create unique domain names for your projects that can be
             accessed on the internet and secure them with an HTTPS certificate, providing a secure
@@ -43,17 +43,27 @@ export default function IndexRoute() {
         gap={{ base: '5', lg: '10' }}
         width={{ base: 'full', sm: 'md' }}
       >
+        {user.isAdmin && (
+          <LandingPageCard
+            path="/admin"
+            pathName="Admin"
+            cardName="Admin"
+            cardDescription="Search, View, and Manage Users, their DNS Records and Certificates."
+          />
+        )}
         <LandingPageCard
           path="/dns-records"
           pathName="Manage DNS Records"
           cardName="DNS Records"
-          cardDescription="DNS Record is a data stored in Domain Name System (DNS) servers, which maps a value to a domain name.  You can create a unique custom domain for each of your projects by submitting a simple form."
+          cardDescription="DNS Records are stored in Domain Name System (DNS) servers, which map a value to a domain name.  You can create a unique custom domain for each of your projects."
+          instructionsPath="/dns-records/instructions"
         />
         <LandingPageCard
           path="/certificate"
           pathName="Manage Certificate"
           cardName="Certificate"
-          cardDescription="When a client visits your website that has an HTTPS (Hypertext Transfer Protocol Secure) certificate, the client's browser verifies the authenticity of the certificate and establishes a secure connection with your website. Any data between the client and your website will be encrypted and cannot be intercepted."
+          cardDescription="An HTTPS Certificate allows a browser to establish a secure connection with your website. Any data between the client and your website will be encrypted and cannot be intercepted."
+          instructionsPath="/certificate/instructions"
         />
       </Flex>
       <Flex paddingTop={{ sm: '20' }}>

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -37,11 +37,12 @@ export default function IndexRoute() {
       </Flex>
       <Flex
         flexDirection={{ base: 'column', md: 'row' }}
+        flexWrap="wrap"
         justifyContent="center"
         paddingY="5"
         paddingX={{ base: '10', md: '5' }}
         gap={{ base: '5', lg: '10' }}
-        width={{ base: 'full', sm: 'md' }}
+        width={{ base: 'full', sm: 'md', md: 'full' }}
       >
         {user.isAdmin && (
           <LandingPageCard

--- a/test/e2e/landing-page.spec.ts
+++ b/test/e2e/landing-page.spec.ts
@@ -25,11 +25,8 @@ test.describe('Landing Page', () => {
   test('DNS Records Instructions Link', async ({ page }) => {
     await page
       .getByRole('paragraph')
-      .filter({
-        hasText:
-          'DNS Record is a data stored in Domain Name System (DNS) servers, which maps a value to a domain name',
-      })
-      .getByRole('link', { name: 'to learn more, see these instructions...' })
+      .getByRole('link', { name: 'these instructions' })
+      .first()
       .click();
 
     await expect(page).toHaveURL('/dns-records/instructions');
@@ -44,10 +41,8 @@ test.describe('Landing Page', () => {
   test('Certificate Instructions Link', async ({ page }) => {
     await page
       .getByRole('paragraph')
-      .filter({
-        hasText: 'When a client visits your website that has an HTTPS (Hypertext Transfer ',
-      })
-      .getByRole('link', { name: 'to learn more, see these instructions...' })
+      .getByRole('link', { name: 'these instructions' })
+      .nth(1)
       .click();
 
     await expect(page).toHaveURL('/certificate/instructions');


### PR DESCRIPTION
We don't currently have a way for an admin to get to the Admin page.  This adds another card to the landing page when a suer is an admin.

I've also cleaned up a few things in the landing page.  However, the responsive widths aren't perfect, so maybe one of you could advise me on how to get it to wrap sooner.

## Regular User
<img width="1384" alt="Screenshot 2023-04-05 at 2 30 26 PM" src="https://user-images.githubusercontent.com/427398/230172991-886a432f-a1b0-4d53-af21-5fdd898f1175.png">

## Admin User
<img width="1387" alt="Screenshot 2023-04-05 at 2 30 42 PM" src="https://user-images.githubusercontent.com/427398/230172992-903d6680-6c9e-4c53-b531-849506048f87.png">
