### PR TITLE
Add separate Certificate Views for different use cases/services

### DIFF
--- a/app/components/certificate/certificate-available.tsx
+++ b/app/components/certificate/certificate-available.tsx
@@ -1,7 +1,18 @@
-import { Divider } from '@chakra-ui/react';
+import {
+  Heading,
+  Tab,
+  TabList,
+  Tabs,
+  TabPanels,
+  Text,
+  OrderedList,
+  ListItem,
+} from '@chakra-ui/react';
 
 import Description from './description';
-import CertificateDisplay from './certificate-display';
+import GeneralPanel from './panels/general';
+import NodePanel from './panels/node';
+import AwsPanel from './panels/aws';
 
 interface CertificateAvailableProps {
   validFromFormatted: string;
@@ -24,20 +35,51 @@ export default function CertificateAvailable({
         validFromFormatted={validFromFormatted}
         validToFormatted={validToFormatted}
       />
-      <Divider />
-      <CertificateDisplay
-        title="Public Key"
-        value={publicKey}
-        description="Public key is intended to be shared widely and is used for encrypting data. The encrypted data can then only be decrypted by the corresponding private key. In other words, anyone can use the public key to encrypt data, but only the private key can be used to decrypt it."
-        pathname="cert"
-      />
-      <Divider />
-      <CertificateDisplay
-        title="Private Key"
-        value={privateKey}
-        description="Private key is a secret and is used for decrypting data that has been encrypted using the corresponding public key."
-        pathname="privkey"
-      />
+
+      <Heading as="h2" size="lg" marginTop={4}>
+        Using Your Certificate
+      </Heading>
+      <Text>
+        Your <em>certificate</em> is made-up of a number of separate parts, and different services
+        will require you to use them in various combinations. These parts include:
+      </Text>
+
+      <OrderedList>
+        <ListItem>
+          <strong>Public Certificate</strong>: public (not secret) certificate that verifies domain
+          ownership
+        </ListItem>
+        <ListItem>
+          <strong>Private Key</strong>: private code (do not share!) used to encrypt/decrypt data
+        </ListItem>
+        <ListItem>
+          <strong>Intermediate Certificate Chain</strong>: set of one or more certificates that link
+          your certificate back to a Certificate Authority, establishing a trust relationship
+        </ListItem>
+        <ListItem>
+          <strong>Full Chain</strong>: your Public Certificate combined with the Intermediate
+          Certificate Chain
+        </ListItem>
+      </OrderedList>
+
+      <Text>
+        You can select from the list of pre-defined services below to help guide you, or see a
+        General view for all of the certificate's parts.
+      </Text>
+
+      <Tabs>
+        <TabList>
+          <Tab>General</Tab>
+          <Tab>Node.js</Tab>
+          <Tab>AWS</Tab>
+        </TabList>
+
+        <TabPanels>
+          <GeneralPanel publicKey={publicKey} privateKey={privateKey} />
+          <NodePanel publicKey={publicKey} privateKey={privateKey} />
+          <AwsPanel publicKey={publicKey} privateKey={privateKey} />
+        </TabPanels>
+      </Tabs>
     </>
   );
 }

--- a/app/components/certificate/panels/aws.tsx
+++ b/app/components/certificate/panels/aws.tsx
@@ -1,0 +1,53 @@
+import { Divider, TabPanel, Text, Link } from '@chakra-ui/react';
+import CertificateDisplay from '../certificate-display';
+
+interface AwsPanelProps {
+  publicKey: string;
+  privateKey: string;
+}
+
+export default function AwsPanel({ publicKey, privateKey }: AwsPanelProps) {
+  return (
+    <TabPanel>
+      <Text marginBottom={4}>
+        You can{' '}
+        <Link
+          href="https://docs.aws.amazon.com/acm/latest/userguide/import-certificate-api-cli.html"
+          isExternal
+        >
+          import your certificate
+        </Link>
+        into{' '}
+        <Link href="https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html" isExternal>
+          AWS Certificate Manager
+        </Link>{' '}
+        and use it with{' '}
+        <Link href="https://docs.aws.amazon.com/acm/latest/userguide/acm-services.html" isExternal>
+          many AWS services
+        </Link>
+        .
+      </Text>
+
+      <CertificateDisplay
+        title="Certificate body"
+        value={publicKey}
+        description="Public certificate body."
+        pathname="cert"
+      />
+      <Divider />
+      <CertificateDisplay
+        title="Certificate private key"
+        value={privateKey}
+        description="Private certificate key is a secret, do not share it."
+        pathname="privkey"
+      />
+      <Divider />
+      <CertificateDisplay
+        title="Certificate chain - optional"
+        value={publicKey}
+        description="Certificate chain includes intermediate certificates used to verify and validate your public certificate."
+        pathname="privkey"
+      />
+    </TabPanel>
+  );
+}

--- a/app/components/certificate/panels/general.tsx
+++ b/app/components/certificate/panels/general.tsx
@@ -1,0 +1,27 @@
+import { Divider, TabPanel } from '@chakra-ui/react';
+import CertificateDisplay from '../certificate-display';
+
+interface GeneralPanelProps {
+  publicKey: string;
+  privateKey: string;
+}
+
+export default function GeneralPanel({ publicKey, privateKey }: GeneralPanelProps) {
+  return (
+    <TabPanel>
+      <CertificateDisplay
+        title="Public Key"
+        value={publicKey}
+        description="Public key is intended to be shared widely and is used for encrypting data. The encrypted data can then only be decrypted by the corresponding private key. In other words, anyone can use the public key to encrypt data, but only the private key can be used to decrypt it."
+        pathname="cert"
+      />
+      <Divider />
+      <CertificateDisplay
+        title="Private Key"
+        value={privateKey}
+        description="Private key is a secret and is used for decrypting data that has been encrypted using the corresponding public key."
+        pathname="privkey"
+      />
+    </TabPanel>
+  );
+}

--- a/app/components/certificate/panels/node.tsx
+++ b/app/components/certificate/panels/node.tsx
@@ -1,0 +1,45 @@
+import { Divider, TabPanel, Text, Link } from '@chakra-ui/react';
+import CertificateDisplay from '../certificate-display';
+
+interface NodePanelProps {
+  publicKey: string;
+  privateKey: string;
+}
+
+export default function NodePanel({ publicKey, privateKey }: NodePanelProps) {
+  return (
+    <TabPanel>
+      <Text marginBottom={4}>
+        You can use your certificate with{' '}
+        <Link
+          href="https://nodejs.org/api/https.html#httpscreateserveroptions-requestlistener"
+          isExternal
+        >
+          Node.js to create a secure HTTPS server
+        </Link>
+        .
+      </Text>
+
+      <CertificateDisplay
+        title="Cert"
+        value={publicKey}
+        description="Public certificate."
+        pathname="cert"
+      />
+      <Divider />
+      <CertificateDisplay
+        title="Key"
+        value={privateKey}
+        description="Private certificate key, do not share it."
+        pathname="privkey"
+      />
+      <Divider />
+      <CertificateDisplay
+        title="CA - optional"
+        value={publicKey}
+        description="The CA Bundle."
+        pathname="cert"
+      />
+    </TabPanel>
+  );
+}

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -63,6 +63,16 @@ export const action = async ({ request }: ActionArgs) => {
   });
 };
 
+function formatDate(val: Date): string {
+  let date = val.toLocaleDateString('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  });
+
+  return date;
+}
+
 export default function CertificateIndexRoute() {
   const user = useEffectiveUser();
   const revalidator = useRevalidator();
@@ -74,16 +84,6 @@ export default function CertificateIndexRoute() {
     },
     certificate?.status === 'pending' ? 15_000 : null
   );
-
-  function formatDate(val: Date): string {
-    let date = val.toLocaleDateString('en-US', {
-      month: 'short',
-      day: '2-digit',
-      year: 'numeric',
-    });
-
-    return date;
-  }
 
   if (certificate?.status === 'pending') {
     return (


### PR DESCRIPTION
I loved @dadolhay's idea in the call today to have some guided-views for working with the various certificate parts, in ways that match the service you are targeting.

I've made a start of this by splitting the certificate UI into panels.  So far I have a General panel, node.js panel, and AWS panel.

This needs the work from #524 to split the cert into more parts.  But once that is done, we can show people exactly what they need, and call it what they expect.

<img width="1019" alt="Screenshot 2023-04-05 at 3 36 26 PM" src="https://user-images.githubusercontent.com/427398/230186925-2cb128a0-bde1-4236-8fff-f23092c4d8b1.png">

<img width="1018" alt="Screenshot 2023-04-05 at 3 36 35 PM" src="https://user-images.githubusercontent.com/427398/230186923-e38eabee-c999-4cae-bbbd-f57ddc560363.png">

<img width="1018" alt="Screenshot 2023-04-05 at 3 36 45 PM" src="https://user-images.githubusercontent.com/427398/230186921-0bd04395-6ac7-4b02-86d5-2d0d8279ce39.png">

