### PR TITLE
Split certificate public key and chain

### DIFF
--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -416,11 +416,18 @@ class LetsEncrypt {
     });
 
     this.#order = await this.#client.finalizeOrder(this.#order, csr);
-    const certificate = await this.#client.getCertificate(this.#order);
+
+    // fullChain is the publicCertificate + the intermediate certificate(s) for Let's Encrypt
+    const fullChain = await this.#client.getCertificate(this.#order);
+
+    // certificate is the public certificate, chain is the intermediate certificate(s) for Let's Encrypt
+    const [certificate, ...chain] = acme.crypto.splitPemChain(fullChain);
 
     return {
       privateKey: key.toString(),
       certificate,
+      chain,
+      fullChain,
       validFrom: new Date(),
       validTo: new Date(this.#order.expires!),
     };

--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -417,7 +417,7 @@ class LetsEncrypt {
 
     this.#order = await this.#client.finalizeOrder(this.#order, csr);
 
-    // fullChain is the publicCertificate + the intermediate certificate(s) for Let's Encrypt
+    // fullChain is the public certificate + the intermediate certificate(s) for Let's Encrypt
     const fullChain = await this.#client.getCertificate(this.#order);
 
     // certificate is the public certificate, chain is the intermediate certificate(s) for Let's Encrypt

--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -422,13 +422,12 @@ class LetsEncrypt {
 
     // certificate is the public certificate, chain is the intermediate certificate(s) for Let's Encrypt
     const [certificate, ...chainArray] = acme.crypto.splitPemChain(fullChain);
-    const chain = chainArray.join('');
+    const chain = chainArray.join('\r\n');
 
     return {
       privateKey: key.toString(),
       certificate,
       chain,
-      fullChain,
       validFrom: new Date(),
       validTo: new Date(this.#order.expires!),
     };

--- a/app/lib/lets-encrypt.server.ts
+++ b/app/lib/lets-encrypt.server.ts
@@ -421,7 +421,8 @@ class LetsEncrypt {
     const fullChain = await this.#client.getCertificate(this.#order);
 
     // certificate is the public certificate, chain is the intermediate certificate(s) for Let's Encrypt
-    const [certificate, ...chain] = acme.crypto.splitPemChain(fullChain);
+    const [certificate, ...chainArray] = acme.crypto.splitPemChain(fullChain);
+    const chain = chainArray.join('');
 
     return {
       privateKey: key.toString(),

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -31,7 +31,14 @@ export function updateCertificateById(
   data: Partial<
     Pick<
       Certificate,
-      'orderUrl' | 'certificate' | 'privateKey' | 'validFrom' | 'validTo' | 'status'
+      | 'orderUrl'
+      | 'certificate'
+      | 'chain'
+      | 'fullChain'
+      | 'privateKey'
+      | 'validFrom'
+      | 'validTo'
+      | 'status'
     >
   >
 ) {

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -31,14 +31,7 @@ export function updateCertificateById(
   data: Partial<
     Pick<
       Certificate,
-      | 'orderUrl'
-      | 'certificate'
-      | 'chain'
-      | 'fullChain'
-      | 'privateKey'
-      | 'validFrom'
-      | 'validTo'
-      | 'status'
+      'orderUrl' | 'certificate' | 'chain' | 'privateKey' | 'validFrom' | 'validTo' | 'status'
     >
   >
 ) {

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -68,14 +68,12 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
     let certificate: string;
     let privateKey: string;
     let chain: string;
-    let fullChain: string;
     let validFrom: Date;
     let validTo: Date;
     try {
       await letsEncrypt.recallOrder(certificateEntry.orderUrl!);
 
-      ({ privateKey, certificate, chain, fullChain, validFrom, validTo } =
-        await letsEncrypt.completeOrder());
+      ({ privateKey, certificate, chain, validFrom, validTo } = await letsEncrypt.completeOrder());
     } catch (e) {
       logger.error('failed to finalize certificate', e);
 
@@ -86,7 +84,6 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
     await certificateModel.updateCertificateById(certificateId, {
       certificate,
       chain,
-      fullChain,
       privateKey,
       validFrom,
       validTo,

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -72,7 +72,8 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
     try {
       await letsEncrypt.recallOrder(certificateEntry.orderUrl!);
 
-      ({ privateKey, certificate, validFrom, validTo } = await letsEncrypt.completeOrder());
+      ({ privateKey, certificate, chain, fullChain, validFrom, validTo } =
+        await letsEncrypt.completeOrder());
     } catch (e) {
       logger.error('failed to finalize certificate', e);
 
@@ -82,6 +83,8 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
 
     await certificateModel.updateCertificateById(certificateId, {
       certificate,
+      chain,
+      fullChain,
       privateKey,
       validFrom,
       validTo,

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -67,6 +67,8 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
      */
     let certificate: string;
     let privateKey: string;
+    let chain: string;
+    let fullChain: string;
     let validFrom: Date;
     let validTo: Date;
     try {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -44,6 +44,8 @@ model Certificate {
   orderUrl     String?           @unique @db.VarChar(255)
   privateKey   String?           @db.Text
   certificate  String?           @db.Text
+  chain        String?           @db.Text
+  fullChain    String?           @db.Text
   validFrom    DateTime?
   validTo      DateTime?
   lastNotified DateTime?

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -45,7 +45,6 @@ model Certificate {
   privateKey   String?           @db.Text
   certificate  String?           @db.Text
   chain        String?           @db.Text
-  fullChain    String?           @db.Text
   validFrom    DateTime?
   validTo      DateTime?
   lastNotified DateTime?


### PR DESCRIPTION
Resolves #524, Resolves #490

- Created another field to store the chain
- Updated certificate code to split the returned result into a public key (stored in the certificate field), and the intermediate certificate(s)/chain (stored in chain field)

Now the UI only shows the public key. I confirmed this by decoding the certificate using an online tool
<img width="461" alt="image" src="https://user-images.githubusercontent.com/67077705/230506706-c3ed183d-3347-4a65-aef7-59a520833fb5.png">
