### PR TITLE
Enhc: Adding the ability to request for new certificate

### DIFF
--- a/app/components/certificate/certificate-available.tsx
+++ b/app/components/certificate/certificate-available.tsx
@@ -20,6 +20,7 @@ interface CertificateAvailableProps {
   validToFormatted: string;
   publicKey: string;
   privateKey: string;
+  isRenewable: boolean;
 }
 
 export default function CertificateAvailable({
@@ -27,6 +28,7 @@ export default function CertificateAvailable({
   validToFormatted,
   publicKey,
   privateKey,
+  isRenewable,
 }: CertificateAvailableProps) {
   return (
     <>
@@ -35,6 +37,7 @@ export default function CertificateAvailable({
         certRequested={true}
         validFromFormatted={validFromFormatted}
         validToFormatted={validToFormatted}
+        isRenewable={isRenewable}
       />
 
       <Heading as="h2" size="lg" marginTop={4}>

--- a/app/components/certificate/description.tsx
+++ b/app/components/certificate/description.tsx
@@ -1,10 +1,13 @@
-import { Flex, Heading, Text, HStack, VStack } from '@chakra-ui/react';
+import { RepeatIcon } from '@chakra-ui/icons';
+import { Flex, Heading, Text, HStack, VStack, IconButton } from '@chakra-ui/react';
+import { Form } from '@remix-run/react';
 
 interface DescriptionSectionProps {
   certRequested: boolean;
   validFromFormatted?: string;
   validToFormatted?: string;
   description: string;
+  isRenewable?: boolean;
 }
 
 export default function DescriptionSection({
@@ -12,6 +15,7 @@ export default function DescriptionSection({
   validFromFormatted,
   validToFormatted,
   description,
+  isRenewable,
 }: DescriptionSectionProps) {
   return (
     <Flex
@@ -22,9 +26,12 @@ export default function DescriptionSection({
       alignItems={{ base: 'center', md: 'flex-start' }}
       textAlign={{ base: 'center', md: 'left' }}
     >
-      <Heading as="h1" size={{ base: 'lg', md: 'xl' }}>
-        Certificate
-      </Heading>
+      <Flex width="100%">
+        <Heading as="h1" size={{ base: 'lg', md: 'xl' }}>
+          Certificate
+        </Heading>
+      </Flex>
+
       <Text>{description}</Text>
       {certRequested && (
         <HStack gap="6" marginTop="2">
@@ -38,6 +45,20 @@ export default function DescriptionSection({
                 <Text fontWeight="bold">Expires On</Text>
                 <Text>{validToFormatted}</Text>
               </VStack>
+
+              <Flex justifyContent="flex-end">
+                <Form method="post">
+                  <IconButton
+                    type="submit"
+                    aria-label="renew-certificate"
+                    icon={<RepeatIcon />}
+                    backgroundColor="transparent"
+                    color="black"
+                    _hover={{ backgroundColor: 'brand.500', color: 'white' }}
+                    isDisabled={isRenewable ? false : true}
+                  />
+                </Form>
+              </Flex>
             </>
           )}
         </HStack>

--- a/app/components/certificate/description.tsx
+++ b/app/components/certificate/description.tsx
@@ -55,7 +55,7 @@ export default function DescriptionSection({
                     backgroundColor="transparent"
                     color="black"
                     _hover={{ backgroundColor: 'brand.500', color: 'white' }}
-                    isDisabled={isRenewable ? false : true}
+                    isDisabled={!isRenewable}
                   />
                 </Form>
               </Flex>

--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -12,7 +12,7 @@ export async function getCertificateByUsername(username: Certificate['username']
   return prisma.certificate
     .findMany({
       where: { username },
-      orderBy: { validFrom: 'desc' },
+      orderBy: { id: 'desc' },
       take: 1,
     })
     .then(([certificate]) => certificate);

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -4,6 +4,8 @@ import { json } from '@remix-run/node';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
 import { useRevalidator } from '@remix-run/react';
 import { useInterval } from 'react-use';
+import { useMemo } from 'react';
+import dayjs from 'dayjs';
 
 import { requireUser, requireUsername } from '~/session.server';
 import pendingSvg from '~/assets/undraw_processing_re_tbdu.svg';
@@ -85,6 +87,15 @@ export default function CertificateIndexRoute() {
     certificate?.status === 'pending' ? 15_000 : null
   );
 
+  const canRenew = useMemo((): boolean => {
+    if (certificate?.validTo) {
+      const validTo = dayjs(certificate.validTo!);
+      const thirtyDays = dayjs().add(30, 'day');
+      return validTo.isBefore(thirtyDays);
+    }
+    return false;
+  }, [certificate]);
+
   if (certificate?.status === 'pending') {
     return (
       <Loading
@@ -108,6 +119,7 @@ export default function CertificateIndexRoute() {
             privateKey={certificate.privateKey!}
             validFromFormatted={formatDate(certificate.validFrom!)}
             validToFormatted={formatDate(certificate.validTo!)}
+            isRenewable={canRenew}
           />
         ) : (
           <CertificateRequestView

--- a/app/routes/__index/certificate/index.tsx
+++ b/app/routes/__index/certificate/index.tsx
@@ -87,7 +87,7 @@ export default function CertificateIndexRoute() {
     certificate?.status === 'pending' ? 15_000 : null
   );
 
-  const canRenew = useMemo((): boolean => {
+  const isRenewable = useMemo((): boolean => {
     if (certificate?.validTo) {
       const validTo = dayjs(certificate.validTo!);
       const thirtyDays = dayjs().add(30, 'day');
@@ -119,7 +119,7 @@ export default function CertificateIndexRoute() {
             privateKey={certificate.privateKey!}
             validFromFormatted={formatDate(certificate.validFrom!)}
             validToFormatted={formatDate(certificate.validTo!)}
-            isRenewable={canRenew}
+            isRenewable={isRenewable}
           />
         ) : (
           <CertificateRequestView


### PR DESCRIPTION
Fixes #513 

- Adds a button to request a new certificate
  - if certificate expiration date is less than 30 days, it will become available to click
- Adding a function to check for 'pending' status called `getCertificatePendingByUsername`
  - The `getCertificateyByUsername` function only works if the certificate has a `validTo` property, otherwise it ignores and places it a the bottom

### How to test ###

> Pre-requisite
- Make sure you have prisma studio open `npm run db:studio`
- A certificate must already exists under the current user
- `validTo` must be set to be less than 30 days from now

> Initial Testing
1. Request for a new certificate
2. Press the 'repeat-icon' besides the expiration date
3. The pending page would load
4. A new certificate should be displayed
5. The button will now be disabled