### PR TITLE
Add an info button linking to DNSChecker

### DIFF
--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -15,9 +15,10 @@ import {
   useDisclosure,
   Spinner,
   HStack,
+  Link,
 } from '@chakra-ui/react';
 import type { DnsRecord } from '@prisma/client';
-import { EditIcon, DeleteIcon, RepeatIcon, CopyIcon } from '@chakra-ui/icons';
+import { EditIcon, DeleteIcon, RepeatIcon, CopyIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import DnsRecordDeleteAlertDialog from './dns-record-delete-alert-dialog';
 
 import { Form, useNavigate, useTransition } from '@remix-run/react';
@@ -107,6 +108,20 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                     <Td>
                       <Flex justifyContent="space-between" alignItems="center">
                         <DnsRecordName dnsRecord={dnsRecord} baseDomain={baseDomain} />
+                        <Link
+                          href={`https://dnschecker.org/#${dnsRecord.type}/${dnsRecord.subdomain}.${baseDomain}`}
+                          isExternal
+                          target="_blank"
+                        >
+                          <Tooltip label="Check DNS Record">
+                            <IconButton
+                              icon={<InfoOutlineIcon color="black" boxSize="5" />}
+                              aria-label="Check DNS record"
+                              variant="ghost"
+                              ml="2"
+                            />
+                          </Tooltip>
+                        </Link>
                         <Tooltip label="Copy subdomain to clipboard">
                           <IconButton
                             icon={<CopyIcon color="black" boxSize="5" />}

--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -16,6 +16,7 @@ import {
   Spinner,
   HStack,
   Link,
+  ButtonGroup,
 } from '@chakra-ui/react';
 import type { DnsRecord } from '@prisma/client';
 import { EditIcon, DeleteIcon, RepeatIcon, CopyIcon, InfoOutlineIcon } from '@chakra-ui/icons';
@@ -108,31 +109,33 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                     <Td>
                       <Flex justifyContent="space-between" alignItems="center">
                         <DnsRecordName dnsRecord={dnsRecord} baseDomain={baseDomain} />
-                        <Link
-                          href={`https://dnschecker.org/#${dnsRecord.type}/${dnsRecord.subdomain}.${baseDomain}`}
-                          isExternal
-                          target="_blank"
-                        >
-                          <Tooltip label="Check DNS Record">
+                        <ButtonGroup>
+                          <Link
+                            href={`https://dnschecker.org/#${dnsRecord.type}/${dnsRecord.subdomain}.${baseDomain}`}
+                            isExternal
+                            target="_blank"
+                          >
+                            <Tooltip label="Check DNS Record">
+                              <IconButton
+                                icon={<InfoOutlineIcon color="black" boxSize="5" />}
+                                aria-label="Check DNS record"
+                                variant="ghost"
+                                ml="2"
+                              />
+                            </Tooltip>
+                          </Link>
+                          <Tooltip label="Copy subdomain to clipboard">
                             <IconButton
-                              icon={<InfoOutlineIcon color="black" boxSize="5" />}
-                              aria-label="Check DNS record"
+                              icon={<CopyIcon color="black" boxSize="5" />}
+                              aria-label="Refresh DNS record"
                               variant="ghost"
                               ml="2"
+                              onClick={() =>
+                                onCopyNameToClipboard(`${dnsRecord.subdomain}.${baseDomain}`)
+                              }
                             />
                           </Tooltip>
-                        </Link>
-                        <Tooltip label="Copy subdomain to clipboard">
-                          <IconButton
-                            icon={<CopyIcon color="black" boxSize="5" />}
-                            aria-label="Refresh DNS record"
-                            variant="ghost"
-                            ml="2"
-                            onClick={() =>
-                              onCopyNameToClipboard(`${dnsRecord.subdomain}.${baseDomain}`)
-                            }
-                          />
-                        </Tooltip>
+                        </ButtonGroup>
                       </Flex>
                     </Td>
                     <Td>{dnsRecord.type}</Td>

--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -115,7 +115,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                             isExternal
                             target="_blank"
                           >
-                            <Tooltip label="Check DNS Record">
+                            <Tooltip label="Check DNS record">
                               <IconButton
                                 icon={<InfoOutlineIcon color="black" boxSize="5" />}
                                 aria-label="Check DNS record"
@@ -124,7 +124,7 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                               />
                             </Tooltip>
                           </Link>
-                          <Tooltip label="Copy subdomain to clipboard">
+                          <Tooltip label="Copy DNS record to clipboard">
                             <IconButton
                               icon={<CopyIcon color="black" boxSize="5" />}
                               aria-label="Refresh DNS record"

--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -124,7 +124,7 @@ export default function DnsRecordsIndexRoute() {
               <Link to="/dns-records/new">
                 <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
               </Link>
-              <ExternalLink href="https://dnschecker.org">
+              <ExternalLink href="https://dnschecker.org" isExternal>
                 <Tooltip label="DNS checker">
                   <IconButton
                     ml={3}

--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -1,7 +1,6 @@
-import { AddIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { AddIcon } from '@chakra-ui/icons';
 import {
   Button,
-  IconButton,
   Center,
   Container,
   Flex,
@@ -10,8 +9,6 @@ import {
   StatLabel,
   StatNumber,
   Text,
-  Tooltip,
-  Link as ExternalLink,
 } from '@chakra-ui/react';
 import { Link } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
@@ -124,16 +121,6 @@ export default function DnsRecordsIndexRoute() {
               <Link to="/dns-records/new">
                 <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
               </Link>
-              <ExternalLink href="https://dnschecker.org" isExternal>
-                <Tooltip label="DNS checker">
-                  <IconButton
-                    ml={3}
-                    icon={<ExternalLinkIcon boxSize={5} />}
-                    aria-label="DNS checker"
-                    variant="ghost"
-                  />
-                </Tooltip>
-              </ExternalLink>
             </Flex>
             <DnsRecordsTable dnsRecords={data.dnsRecords} />
           </>

--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -1,6 +1,7 @@
-import { AddIcon } from '@chakra-ui/icons';
+import { AddIcon, ExternalLinkIcon } from '@chakra-ui/icons';
 import {
   Button,
+  IconButton,
   Center,
   Container,
   Flex,
@@ -9,6 +10,8 @@ import {
   StatLabel,
   StatNumber,
   Text,
+  Tooltip,
+  Link as ExternalLink,
 } from '@chakra-ui/react';
 import { Link } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
@@ -121,6 +124,16 @@ export default function DnsRecordsIndexRoute() {
               <Link to="/dns-records/new">
                 <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
               </Link>
+              <ExternalLink href="https://dnschecker.org">
+                <Tooltip label="DNS checker">
+                  <IconButton
+                    ml={3}
+                    icon={<ExternalLinkIcon boxSize={5} />}
+                    aria-label="DNS checker"
+                    variant="ghost"
+                  />
+                </Tooltip>
+              </ExternalLink>
             </Flex>
             <DnsRecordsTable dnsRecords={data.dnsRecords} />
           </>


### PR DESCRIPTION
## Description
Closes #440 by adding a button linking to https://dnschecker.org/ to show DNS record info.

### Steps to test
- Run the project locally
- Create a new DNS Record
- Interact with the info button:


https://user-images.githubusercontent.com/50856799/230491653-1c7aec14-0ca0-4aed-8417-00ff04b436a5.mov



