### PR TITLE
Truncate long DNS Record values in table

### DIFF
--- a/app/components/dns-records-table.tsx
+++ b/app/components/dns-records-table.tsx
@@ -3,6 +3,7 @@ import {
   Table,
   Tr,
   Th,
+  Text,
   Thead,
   Tbody,
   TableContainer,
@@ -121,7 +122,13 @@ export default function DnsRecordsTable(props: DnsRecordsTableProps) {
                       </Flex>
                     </Td>
                     <Td>{dnsRecord.type}</Td>
-                    <Td>{dnsRecord.value}</Td>
+                    <Td>
+                      <Tooltip label={dnsRecord.value}>
+                        <Text isTruncated maxWidth="20ch">
+                          {dnsRecord.value}
+                        </Text>
+                      </Tooltip>
+                    </Td>
                     <Td>
                       <Flex alignItems="center">
                         {dnsRecord.expiresAt.toLocaleDateString('en-US')}


### PR DESCRIPTION
A CNAME , AAAA, or TXT record value can be quite long:

<img width="1124" alt="Screenshot 2023-04-06 at 4 56 32 PM" src="https://user-images.githubusercontent.com/427398/230492432-38912a69-4e2d-4500-b9c5-8157db2f8800.png">

This caps the max width to 20 characters.  Hovering shows the full record text:

<img width="1123" alt="Screenshot 2023-04-06 at 5 11 04 PM" src="https://user-images.githubusercontent.com/427398/230494848-73151f4e-ef40-4a24-8cf7-d97e06c4a0b2.png">
