### PR TITLE
process certificate expiration

### DIFF
--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -48,3 +48,16 @@ export function deleteCertificateById(id: Certificate['id']) {
 export function getTotalCertificateCount() {
   return prisma.certificate.count();
 }
+
+export function getExpiredCertificates() {
+  return prisma.certificate.findMany({
+    where: {
+      validTo: {
+        lt: new Date(),
+      },
+    },
+    include: {
+      user: true,
+    },
+  });
+}

--- a/app/queues/common/expiration-request.server.ts
+++ b/app/queues/common/expiration-request.server.ts
@@ -70,9 +70,9 @@ const expirationRequestWorker = new Worker(
             subject: 'My.Custom.Domain certificate expired',
             message: `${user.displayName}, your certificate with domain: ${domain} has expired.`,
           });
-          // delete certificate from DB
-          await deleteCertificateById(id);
         }
+        // delete certificate from DB
+        await deleteCertificateById(id);
       });
     } catch (err) {
       throw new UnrecoverableError(`Unable to process certificate expiration: ${err}`);

--- a/app/queues/common/expiration-request.server.ts
+++ b/app/queues/common/expiration-request.server.ts
@@ -62,16 +62,18 @@ const expirationRequestWorker = new Worker(
       logger.info('process certificate expiration');
       let certificates = await getExpiredCertificates();
       certificates.map(async ({ id, username, domain, user }) => {
+        // get the most recent and successfully issued certificate from the DB
         let mostRecentCertificate = await getCertificateByUsername(username);
-        // add notification jobs
+        // check if the most recent certificate matches the id of expired certificate
         if (mostRecentCertificate.id === id) {
+          // add notification jobs
           await addNotification({
             emailAddress: user.email,
             subject: 'My.Custom.Domain certificate expired',
             message: `${user.displayName}, your certificate with domain: ${domain} has expired.`,
           });
         }
-        // delete certificate from DB
+        // delete all expired certificates from DB
         await deleteCertificateById(id);
       });
     } catch (err) {


### PR DESCRIPTION
## Description
Resolves #528 by deleting expired certificates from the database and sending an email notification.

### Steps to test
- Set the job to repeat every 5 seconds
- Run the project
- Request a certificate
- Run `npm run studio` and set the `validTo` date in the past
- Confirm the expired certificate is deleted from the DB
- Navigate to http://localhost:8025 to see the email notification:
<img width="1408" alt="list view" src="https://user-images.githubusercontent.com/50856799/230617732-ffa67ed2-a566-4ee6-82d9-942557c75eed.png">

