### PR TITLE
Prevent duplicate CNAME for a user

### DIFF
--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -112,25 +112,14 @@ export async function doesDnsRecordExist(
   data: Pick<DnsRecord, 'username' | 'type' | 'subdomain' | 'value'>
 ) {
   const { username, type, subdomain, value } = data;
-  let count = 0;
-  if (type === 'CNAME') {
-    count = await prisma.dnsRecord.count({
-      where: {
-        username,
-        type,
-        subdomain,
-      },
-    });
-  } else {
-    count = await prisma.dnsRecord.count({
-      where: {
-        username,
-        type,
-        subdomain,
-        value,
-      },
-    });
-  }
+  const count = await prisma.dnsRecord.count({
+    where: {
+      username,
+      type,
+      subdomain,
+      value: type === 'CNAME' ? undefined : value,
+    },
+  });
 
   return count > 0;
 }

--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -117,9 +117,13 @@ export async function doesDnsRecordExist(
       username,
       type,
       subdomain,
-      /* For CNAME records, we would consider it a duplicate if username and subdomain are the same. 
-      Value doesn't matter, so "undefine" lets Prisma knows we are not looking for it in WHERE clause.
-      */
+      /**
+       * For CNAME records, we would consider it a duplicate if username
+       * and subdomain are the same.
+       *
+       * Value doesn't matter in that case, so "undefined" lets Prisma
+       * knows we are not looking for it in WHERE clause.
+       */
       value: type === 'CNAME' ? undefined : value,
     },
   });

--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -112,14 +112,25 @@ export async function doesDnsRecordExist(
   data: Pick<DnsRecord, 'username' | 'type' | 'subdomain' | 'value'>
 ) {
   const { username, type, subdomain, value } = data;
-  const count = await prisma.dnsRecord.count({
-    where: {
-      username,
-      type,
-      subdomain,
-      value,
-    },
-  });
+  let count = 0;
+  if (type === 'CNAME') {
+    count = await prisma.dnsRecord.count({
+      where: {
+        username,
+        type,
+        subdomain,
+      },
+    });
+  } else {
+    count = await prisma.dnsRecord.count({
+      where: {
+        username,
+        type,
+        subdomain,
+        value,
+      },
+    });
+  }
 
   return count > 0;
 }

--- a/app/models/dns-record.server.ts
+++ b/app/models/dns-record.server.ts
@@ -117,6 +117,9 @@ export async function doesDnsRecordExist(
       username,
       type,
       subdomain,
+      /* For CNAME records, we would consider it a duplicate if username and subdomain are the same. 
+      Value doesn't matter, so "undefine" lets Prisma knows we are not looking for it in WHERE clause.
+      */
       value: type === 'CNAME' ? undefined : value,
     },
   });


### PR DESCRIPTION
As part of #442 
This prevents duplicate CNAME records from the same user with the same name/`subdomain`.

## Test
From our website, you can try to create multiple CNAME records with the same name/`subdomain` as the same user.
You should see an error that says "DNS Record already exists".