### PR TITLE
Make links more obvious

### DIFF
--- a/app/components/certificate/panels/aws.tsx
+++ b/app/components/certificate/panels/aws.tsx
@@ -16,7 +16,7 @@ export default function AwsPanel({ publicKey, privateKey }: AwsPanelProps) {
           isExternal
         >
           import your certificate
-        </Link>
+        </Link>{' '}
         into{' '}
         <Link href="https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html" isExternal>
           AWS Certificate Manager

--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -6,9 +6,10 @@ import {
   CardHeader,
   Flex,
   Heading,
+  Link,
   Text,
 } from '@chakra-ui/react';
-import { Link } from '@remix-run/react';
+import { Link as ReactLink } from '@remix-run/react';
 
 interface LandingPageCardProps {
   path: string;
@@ -38,16 +39,16 @@ export default function LandingPageCard({
           {instructionsPath && (
             <Text>
               To learn more, see{' '}
-              <Text as={Link} to={instructionsPath} color="brand.500" textDecor="underline">
+              <Link as={ReactLink} to={instructionsPath}>
                 these instructions
-              </Text>
+              </Link>
               .
             </Text>
           )}
         </Flex>
       </CardBody>
       <CardFooter>
-        <Button as={Link} to={{ pathname: path }} size={{ base: 'xs', xs: 'sm', md: 'md' }}>
+        <Button as={ReactLink} to={{ pathname: path }} size={{ base: 'xs', xs: 'sm', md: 'md' }}>
           {pathName}
         </Button>
       </CardFooter>

--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -9,7 +9,7 @@ import {
   Link,
   Text,
 } from '@chakra-ui/react';
-import { Link as ReactLink } from '@remix-run/react';
+import { Link as RemixLink } from '@remix-run/react';
 
 interface LandingPageCardProps {
   path: string;
@@ -39,7 +39,7 @@ export default function LandingPageCard({
           {instructionsPath && (
             <Text>
               To learn more, see{' '}
-              <Link as={ReactLink} to={instructionsPath}>
+              <Link as={RemixLink} to={instructionsPath}>
                 these instructions
               </Link>
               .
@@ -48,7 +48,7 @@ export default function LandingPageCard({
         </Flex>
       </CardBody>
       <CardFooter>
-        <Button as={ReactLink} to={{ pathname: path }} size={{ base: 'xs', xs: 'sm', md: 'md' }}>
+        <Button as={RemixLink} to={{ pathname: path }} size={{ base: 'xs', xs: 'sm', md: 'md' }}>
           {pathName}
         </Button>
       </CardFooter>

--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -63,10 +63,11 @@ export default function IndexRoute() {
         />
       </Flex>
       <Flex paddingTop={{ sm: '20' }}>
-        <Link href="https://www.senecacollege.ca/about/policies/information-technology-acceptable-use-policy.html">
-          <Text fontSize={{ base: 'xs', sm: 'sm', md: 'md' }} color="brand.500">
-            Seneca's IT Acceptable Use Policy
-          </Text>
+        <Link
+          href="https://www.senecacollege.ca/about/policies/information-technology-acceptable-use-policy.html"
+          fontSize={{ base: 'xs', sm: 'sm', md: 'md' }}
+        >
+          Seneca's IT Acceptable Use Policy
         </Link>
       </Flex>
     </VStack>

--- a/app/theme/index.ts
+++ b/app/theme/index.ts
@@ -1,4 +1,4 @@
-import { extendTheme, withDefaultColorScheme } from '@chakra-ui/react';
+import { defineStyleConfig, extendTheme, withDefaultColorScheme } from '@chakra-ui/react';
 import colors from './colors';
 import breakpoints from './breakpoints';
 
@@ -6,6 +6,14 @@ const theme = extendTheme(
   {
     colors,
     breakpoints,
+    components: {
+      Link: defineStyleConfig({
+        baseStyle: {
+          color: 'brand.500',
+          textDecor: 'underline',
+        },
+      }),
+    },
   },
   withDefaultColorScheme({ colorScheme: 'brand' })
 );


### PR DESCRIPTION
Fixes #539 

This changes all Chakra UI `Link` Components to have a base color of red (from our color theme), and a base text decoration of underline:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/67077705/230635064-d8963ab7-f36a-4b43-bbb2-01122dee38b3.png">

Since this only changes the base style, you can override the style as you normally would for any Charka UI component. Eg:
```ts
<Link color="black">
```

I have also updated the landing page links to use Charka UI's `Link` component, but as [Remix's Link](https://remix.run/docs/en/1.15.0/components/link) component. This preserves client-side routing but also keeps the Chakra UI styles ([Relevant Chakra UI docs](https://chakra-ui.com/docs/components/link/usage#usage-with-routing-library))

#### Steps to test
- Run the app
- Navigate to different links
- Check that links preserve client-side routing when routing to our website
- Check that link have the base style of red with an underline