### PR TITLE
Add label to 'renew' button

### DIFF
--- a/app/components/certificate/description.tsx
+++ b/app/components/certificate/description.tsx
@@ -1,6 +1,6 @@
 import { RepeatIcon } from '@chakra-ui/icons';
 import { Form } from '@remix-run/react';
-import { Flex, Text, HStack, IconButton, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
+import { Flex, Text, HStack, Button, Stat, StatLabel, StatNumber } from '@chakra-ui/react';
 
 interface DescriptionSectionProps {
   certRequested: boolean;
@@ -35,15 +35,9 @@ export default function DescriptionSection({
 
               <Flex justifyContent="flex-end">
                 <Form method="post">
-                  <IconButton
-                    type="submit"
-                    aria-label="renew-certificate"
-                    icon={<RepeatIcon />}
-                    backgroundColor="transparent"
-                    color="black"
-                    _hover={{ backgroundColor: 'brand.500', color: 'white' }}
-                    isDisabled={!isRenewable}
-                  />
+                  <Button type="submit" rightIcon={<RepeatIcon />} isDisabled={!isRenewable}>
+                    Renew Certificate
+                  </Button>
                 </Form>
               </Flex>
             </>


### PR DESCRIPTION
## Description
Resolves #548 by adding text to Renew button.

### Steps to test
- Run the project locally
- Navigate to http://localhost:8080/certificate
- Interact with the button:
<img width="696" alt="renew button" src="https://user-images.githubusercontent.com/50856799/230792093-d98f966f-81df-4548-8c05-89476ea6326e.png">
