### PR TITLE
Clean-up balance of certificate request text

### DIFF
--- a/app/components/display-page.tsx
+++ b/app/components/display-page.tsx
@@ -18,15 +18,18 @@ export default function DisplayPage({ img, desc }: DisplayPageProps) {
           <Image src={img} />
         </Flex>
 
-        <Heading
-          as="h2"
-          size={{ base: 'md', sm: 'lg', md: 'xl' }}
-          fontFamily="heading"
-          fontWeight="light"
-          color="brand.500"
-        >
-          {desc}
-        </Heading>
+        <Center>
+          <Heading
+            as="h2"
+            size={{ base: 'md', sm: 'lg', md: 'xl' }}
+            fontFamily="heading"
+            fontWeight="light"
+            color="brand.500"
+            maxWidth="30ch"
+          >
+            {desc}
+          </Heading>
+        </Center>
       </Flex>
     </Center>
   );


### PR DESCRIPTION
This cleans up the balance of the text when requesting a certificate

Before

<img width="1144" alt="Screenshot 2023-04-09 at 5 01 48 PM" src="https://user-images.githubusercontent.com/427398/230796404-43aaeb59-c6a9-4972-ba6e-10b479642d84.png">


After

<img width="1149" alt="Screenshot 2023-04-09 at 5 01 05 PM" src="https://user-images.githubusercontent.com/427398/230796395-a7e6a6c6-e7b4-4cfb-bf83-8a8cb8a1445b.png">
