### PR TITLE
Add asterisk in front of domain for certificate page and emails

### DIFF
--- a/app/components/certificate/certificate-request.tsx
+++ b/app/components/certificate/certificate-request.tsx
@@ -48,7 +48,7 @@ export default function CertificateRequestView({ domain, isFailed }: Certificate
           alignItems={{ base: 'center', md: 'flex-start' }}
         >
           <Text fontWeight="bold">Domain Name:&nbsp;</Text>
-          <Text>{domain}</Text>
+          <Text>*.{domain}</Text>
         </Flex>
       </Flex>
       <Form method="post" onSubmit={() => setIsDisabled(true)}>

--- a/app/queues/certificate/certificate-error-handler.server.ts
+++ b/app/queues/certificate/certificate-error-handler.server.ts
@@ -78,7 +78,7 @@ export const initCertificateErrorHandler = () => {
       await addNotification({
         emailAddress: certificateEntry.user.email,
         subject: 'My.Custom.Domain certificate request failed',
-        message: `${certificateEntry.user.displayName}, your certificate request with domain: ${certificateEntry.domain} has failed. Log in to My.Custom.Domain to try again.`,
+        message: `${certificateEntry.user.displayName}, your certificate request with domain: *.${certificateEntry.domain} has failed. Log in to My.Custom.Domain to try again.`,
       });
 
       logger.info('Cleanup completed on failed certificate flow', { rootDomain, certificateId });

--- a/app/queues/certificate/order-completer-worker.server.ts
+++ b/app/queues/certificate/order-completer-worker.server.ts
@@ -98,7 +98,7 @@ export const orderCompleterWorker = new Worker<CertificateJobData>(
     await addNotification({
       emailAddress: certificateEntry.user.email,
       subject: 'My.Custom.Domain certificate ready',
-      message: `${certificateEntry.user.displayName}, your certificate with domain: ${certificateEntry.domain} is ready. Log in to My.Custom.Domain to view/manage it.`,
+      message: `${certificateEntry.user.displayName}, your certificate with domain: *.${certificateEntry.domain} is ready. Log in to My.Custom.Domain to view/manage it.`,
     });
   },
   { connection: redis }

--- a/app/queues/common/expiration-request.server.ts
+++ b/app/queues/common/expiration-request.server.ts
@@ -70,7 +70,7 @@ const expirationRequestWorker = new Worker(
           await addNotification({
             emailAddress: user.email,
             subject: 'My.Custom.Domain certificate expired',
-            message: `${user.displayName}, your certificate with domain: ${domain} has expired.`,
+            message: `${user.displayName}, your certificate with domain: *.${domain} has expired.`,
           });
         }
         // delete all expired certificates from DB


### PR DESCRIPTION
Fixes #526 

#### Changes made
- Changed Domain Name: `user1.starchart.com` to `*.user1.starchart.com` on certificate page.
- Changed certificate emails to contain `with domain: *.user1.starchart.com` instead of `with domain: user1.starchart.com`