### PR TITLE
Update framer-motion to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "dayjs": "^1.11.7",
         "docker-secret": "^2.0.6",
         "express": "^4.18.2",
-        "framer-motion": "^6.5.1",
+        "framer-motion": "^10.11.2",
         "helmet": "^6.1.1",
         "http-graceful-shutdown": "^3.1.13",
         "ioredis": "^5.3.1",
@@ -4989,64 +4989,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "3.1.0",
         "@jridgewell/sourcemap-codec": "1.4.14"
-      }
-    },
-    "node_modules/@motionone/animation": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
-      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
-      "dependencies": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "dependencies": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/easing": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
-      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
-      "dependencies": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/generators": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
-      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "node_modules/@motionone/types": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
-    },
-    "node_modules/@motionone/utils": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
-      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
-      "dependencies": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
       }
     },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
@@ -11088,23 +11030,26 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.11.2.tgz",
+      "integrity": "sha512-IrwuC9regNOU99JoM/Z62CAMA3awGV6AcF7e3bcgXk/ZoNlGSt5aVq0J7UAwtLmCkwVlRvBkiMnvv2mZ1GW2pg==",
       "dependencies": {
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.4.0"
       },
       "optionalDependencies": {
         "@emotion/is-prop-valid": "^0.8.2"
       },
       "peerDependencies": {
-        "react": ">=16.8 || ^17.0.0 || ^18.0.0",
-        "react-dom": ">=16.8 || ^17.0.0 || ^18.0.0"
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/framer-motion/node_modules/@emotion/is-prop-valid": {
@@ -11121,14 +11066,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
       "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
       "optional": true
-    },
-    "node_modules/framer-motion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
     },
     "node_modules/framesync": {
       "version": "6.1.2",
@@ -11746,11 +11683,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "node_modules/hoist-non-react-statics": {
       "version": "3.3.2",
@@ -15653,25 +15585,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "dependencies": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/popmotion/node_modules/framesync": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-      "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -17713,15 +17626,6 @@
       "dev": true,
       "dependencies": {
         "inline-style-parser": "0.1.1"
-      }
-    },
-    "node_modules/style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "dependencies": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/stylis": {
@@ -23050,64 +22954,6 @@
         "@jridgewell/sourcemap-codec": "1.4.14"
       }
     },
-    "@motionone/animation": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/animation/-/animation-10.15.1.tgz",
-      "integrity": "sha512-mZcJxLjHor+bhcPuIFErMDNyrdb2vJur8lSfMCsuCB4UyV8ILZLvK+t+pg56erv8ud9xQGK/1OGPt10agPrCyQ==",
-      "requires": {
-        "@motionone/easing": "^10.15.1",
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/dom": {
-      "version": "10.12.0",
-      "resolved": "https://registry.npmjs.org/@motionone/dom/-/dom-10.12.0.tgz",
-      "integrity": "sha512-UdPTtLMAktHiqV0atOczNYyDd/d8Cf5fFsd1tua03PqTwwCe/6lwhLSQ8a7TbnQ5SN0gm44N1slBfj+ORIhrqw==",
-      "requires": {
-        "@motionone/animation": "^10.12.0",
-        "@motionone/generators": "^10.12.0",
-        "@motionone/types": "^10.12.0",
-        "@motionone/utils": "^10.12.0",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/easing": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/easing/-/easing-10.15.1.tgz",
-      "integrity": "sha512-6hIHBSV+ZVehf9dcKZLT7p5PEKHGhDwky2k8RKkmOvUoYP3S+dXsKupyZpqx5apjd9f+php4vXk4LuS+ADsrWw==",
-      "requires": {
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/generators": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/generators/-/generators-10.15.1.tgz",
-      "integrity": "sha512-67HLsvHJbw6cIbLA/o+gsm7h+6D4Sn7AUrB/GPxvujse1cGZ38F5H7DzoH7PhX+sjvtDnt2IhFYF2Zp1QTMKWQ==",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "@motionone/utils": "^10.15.1",
-        "tslib": "^2.3.1"
-      }
-    },
-    "@motionone/types": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/types/-/types-10.15.1.tgz",
-      "integrity": "sha512-iIUd/EgUsRZGrvW0jqdst8st7zKTzS9EsKkP+6c6n4MPZoQHwiHuVtTQLD6Kp0bsBLhNzKIBlHXponn/SDT4hA=="
-    },
-    "@motionone/utils": {
-      "version": "10.15.1",
-      "resolved": "https://registry.npmjs.org/@motionone/utils/-/utils-10.15.1.tgz",
-      "integrity": "sha512-p0YncgU+iklvYr/Dq4NobTRdAPv9PveRDUXabPEeOjBLSO/1FNB2phNTZxOxpi1/GZwYpAoECEa0Wam+nsmhSw==",
-      "requires": {
-        "@motionone/types": "^10.15.1",
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.3.1"
-      }
-    },
     "@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.0.tgz",
@@ -27534,17 +27380,12 @@
       "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="
     },
     "framer-motion": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-6.5.1.tgz",
-      "integrity": "sha512-o1BGqqposwi7cgDrtg0dNONhkmPsUFDaLcKXigzuTFC5x58mE8iyTazxSudFzmT6MEyJKfjjU8ItoMe3W+3fiw==",
+      "version": "10.11.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.11.2.tgz",
+      "integrity": "sha512-IrwuC9regNOU99JoM/Z62CAMA3awGV6AcF7e3bcgXk/ZoNlGSt5aVq0J7UAwtLmCkwVlRvBkiMnvv2mZ1GW2pg==",
       "requires": {
         "@emotion/is-prop-valid": "^0.8.2",
-        "@motionone/dom": "10.12.0",
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "popmotion": "11.0.3",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
+        "tslib": "^2.4.0"
       },
       "dependencies": {
         "@emotion/is-prop-valid": {
@@ -27561,14 +27402,6 @@
           "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
           "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
           "optional": true
-        },
-        "framesync": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
         }
       }
     },
@@ -28038,11 +27871,6 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/helmet/-/helmet-6.1.1.tgz",
       "integrity": "sha512-+lpiPR2U5Z9gZnJiLEhK+ta7Z+NSbWyyQCdOP051T8vpPOfd4I5p66cdTgt5hsRXYbJjWNwmga3zjwTHr2rSpw=="
-    },
-    "hey-listen": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/hey-listen/-/hey-listen-1.0.8.tgz",
-      "integrity": "sha512-COpmrF2NOg4TBWUJ5UVyaCU2A88wEMkUPK4hNqyCkqHbxT92BbvfjoSozkAIIm6XhicGlJHhFdullInrdhwU8Q=="
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",
@@ -30815,27 +30643,6 @@
       "integrity": "sha512-zD7aonO+07kOTthsrCR3YCVnDcqSHIJpdFUtZEMOb6//1Rc7/6mZDRdw+nlzcQiQltOOsiqI3rrSyn/SlyjnJQ==",
       "dev": true
     },
-    "popmotion": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/popmotion/-/popmotion-11.0.3.tgz",
-      "integrity": "sha512-Y55FLdj3UxkR7Vl3s7Qr4e9m0onSnP8W7d/xQLsoJM40vs6UKHFdygs6SWryasTZYqugMjm3BepCF4CWXDiHgA==",
-      "requires": {
-        "framesync": "6.0.1",
-        "hey-listen": "^1.0.8",
-        "style-value-types": "5.0.0",
-        "tslib": "^2.1.0"
-      },
-      "dependencies": {
-        "framesync": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/framesync/-/framesync-6.0.1.tgz",
-          "integrity": "sha512-fUY88kXvGiIItgNC7wcTOl0SNRCVXMKSWW2Yzfmn7EKNc+MpCzcz9DhdHcdjbrtN3c6R4H5dTY2jiCpPdysEjA==",
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
-      }
-    },
     "postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -32372,15 +32179,6 @@
       "dev": true,
       "requires": {
         "inline-style-parser": "0.1.1"
-      }
-    },
-    "style-value-types": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/style-value-types/-/style-value-types-5.0.0.tgz",
-      "integrity": "sha512-08yq36Ikn4kx4YU6RD7jWEv27v4V+PUsOGa4n/as8Et3CuODMJQ00ENeAVXAeydX4Z2j1XHZF1K2sX4mGl18fA==",
-      "requires": {
-        "hey-listen": "^1.0.8",
-        "tslib": "^2.1.0"
       }
     },
     "stylis": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "dayjs": "^1.11.7",
     "docker-secret": "^2.0.6",
     "express": "^4.18.2",
-    "framer-motion": "^6.5.1",
+    "framer-motion": "^10.11.2",
     "helmet": "^6.1.1",
     "http-graceful-shutdown": "^3.1.13",
     "ioredis": "^5.3.1",


### PR DESCRIPTION
As far as I can tell, the specific instructions in https://chakra-ui.com/getting-started/remix-guide re: using `framer-motion@v6` are out of date.

I've updated it locally to `10.11.2` and it's being used in various components we use:

```sh
$ npm list framer-motion
@senecacdot/starchart@0.9.0 /Users/humphd/repos/starchart
├─┬ @chakra-ui/react@2.5.5
│ ├─┬ @chakra-ui/accordion@2.1.11
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/menu@2.1.12
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/modal@2.2.11
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/popover@2.1.9
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/switch@2.0.26
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/toast@6.1.1
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/tooltip@2.2.7
│ │ └── framer-motion@10.11.2 deduped
│ ├─┬ @chakra-ui/transition@2.0.16
│ │ └── framer-motion@10.11.2 deduped
│ └── framer-motion@10.11.2 deduped
└── framer-motion@10.11.2
```

Specifically, we use Accordion, Tooltip, and Toast (possibly others via composition).

I've tested all the places I can think that use these, and it all *seems* to be fine.  I've [tried asking in the Chakra-UI discussions](https://github.com/chakra-ui/chakra-ui/discussions/7320), but so far not got any word on why this is so out of date.

If a couple of you would be willing to test the app locally with this change, especially on Windows or mobile, that would be good.  I think we can probably just update this.