### PR TITLE
Restructure expiration notification worker code

### DIFF
--- a/services/expiration/expiration-notification.server.ts
+++ b/services/expiration/expiration-notification.server.ts
@@ -53,34 +53,30 @@ export function init() {
         logger.debug(`Notifications: processing job ${job.name}`);
         let dnsRecords = await getExpiringDnsRecords();
         await Promise.all(
-          dnsRecords.map(async ({ id, subdomain, expiresAt, lastNotified, user }) => {
-            if (!lastNotified || lastNotified < dayjs().subtract(30, 'd').toDate()) {
-              await updateStatusAndNotify(type, id, {
-                emailAddress: user.email,
-                subject: 'My.Custom.Domain DNS record approaching expiration',
-                message: `${
-                  user.displayName
-                }, this is a friendly reminder that your DNS record with subdomain: ${subdomain} will expire on: ${expiresAt.toLocaleDateString(
-                  'en-CA'
-                )}. Log in to My.Custom.Domain to renew.`,
-              });
-            }
+          dnsRecords.map(async ({ id, subdomain, expiresAt, user }) => {
+            await updateStatusAndNotify(type, id, {
+              emailAddress: user.email,
+              subject: 'My.Custom.Domain DNS record approaching expiration',
+              message: `${
+                user.displayName
+              }, this is a friendly reminder that your DNS record with subdomain: ${subdomain} will expire on: ${expiresAt.toLocaleDateString(
+                'en-CA'
+              )}. Log in to My.Custom.Domain to renew.`,
+            });
           })
         );
         let certificates = await getExpiringCertificates();
         await Promise.all(
-          certificates.map(async ({ id, domain, validTo, lastNotified, user }) => {
-            if (!lastNotified || lastNotified < dayjs().subtract(30, 'd').toDate()) {
-              await updateStatusAndNotify(type, id, {
-                emailAddress: user.email,
-                subject: 'My.Custom.Domain certificate approaching expiration',
-                message: `${
-                  user.displayName
-                }, this is a friendly reminder that your certificate with domain: ${domain} will expire ${
-                  validTo ? `on: ${validTo.toLocaleDateString('en-CA')}` : `in less than 30 days.`
-                }. Log in to My.Custom.Domain to renew. `,
-              });
-            }
+          certificates.map(async ({ id, domain, validTo, user }) => {
+            await updateStatusAndNotify(type, id, {
+              emailAddress: user.email,
+              subject: 'My.Custom.Domain certificate approaching expiration',
+              message: `${
+                user.displayName
+              }, this is a friendly reminder that your certificate with domain: ${domain} will expire ${
+                validTo ? `on: ${validTo.toLocaleDateString('en-CA')}` : `in less than 30 days.`
+              }. Log in to My.Custom.Domain to renew. `,
+            });
           })
         );
 

--- a/services/expiration/expiration-notification.server.ts
+++ b/services/expiration/expiration-notification.server.ts
@@ -69,7 +69,9 @@ export function init() {
                 subject: 'My.Custom.Domain DNS record approaching expiration',
                 message: `${
                   user.displayName
-                }, this is a friendly reminder that your DNS record with subdomain: ${subdomain} will expire on: ${expiresAt.toLocaleDateString()} Log in to My.Custom.Domain to renew.`,
+                }, this is a friendly reminder that your DNS record with subdomain: ${subdomain} will expire on: ${expiresAt.toLocaleDateString(
+                  'en-CA'
+                )}. Log in to My.Custom.Domain to renew.`,
               });
             }
           })
@@ -87,7 +89,7 @@ export function init() {
                 message: `${
                   user.displayName
                 }, this is a friendly reminder that your certificate with domain: ${domain} will expire ${
-                  validTo ? `on: ${validTo.toLocaleTimeString()}` : `in less than 30 days.`
+                  validTo ? `on: ${validTo.toLocaleDateString('en-CA')}` : `in less than 30 days.`
                 }. Log in to My.Custom.Domain to renew. `,
               });
             }

--- a/services/expiration/expiration-notification.server.ts
+++ b/services/expiration/expiration-notification.server.ts
@@ -85,7 +85,7 @@ export function init() {
             ) {
               await updateStatusAndNotify(type, id, {
                 emailAddress: user.email,
-                subject: 'My.Custom.Domain Certificate approaching expiration',
+                subject: 'My.Custom.Domain certificate approaching expiration',
                 message: `${
                   user.displayName
                 }, this is a friendly reminder that your certificate with domain: ${domain} will expire ${


### PR DESCRIPTION
## Description
Closes #11. The code to process expiration notifications was already implemented in a previous PR. This PR restructures the code slightly to add context to the reminder notices we roll out a month before DNS records and certificate expiration. We are also checking if the status is "issued" for certificates prior to notifying.

### Steps to Test:
- Run the project locally
- Modify the `validTo` (for Certs) and `expiresAt` for (DNS records)
- Navigate to http://localhost:8025 to view notification after 5 mins:
<img width="1326" alt="list view" src="https://user-images.githubusercontent.com/50856799/231241272-5000a663-8d52-48a0-9b16-fcbba777e731.png">
<img width="1424" alt="detailed view" src="https://user-images.githubusercontent.com/50856799/231480964-a705622b-ca3f-457a-928a-9d1b49433e05.png">

