### PR TITLE
Refactor to use useClipboard() hook

### DIFF
--- a/app/components/admin/users-table.tsx
+++ b/app/components/admin/users-table.tsx
@@ -9,13 +9,12 @@ import {
   Card,
   IconButton,
   Tooltip,
-  useToast,
   Flex,
   HStack,
   Spinner,
   Text,
 } from '@chakra-ui/react';
-import { CopyIcon, DeleteIcon } from '@chakra-ui/icons';
+import { DeleteIcon } from '@chakra-ui/icons';
 import { FaTheaterMasks } from 'react-icons/fa';
 import { Form, useNavigation } from '@remix-run/react';
 
@@ -30,17 +29,7 @@ interface UsersTableProps {
 }
 
 export default function UsersTable({ users, searchText }: UsersTableProps) {
-  const toast = useToast();
   const navigation = useNavigation();
-
-  function onCopyNameToClipboard(subdomain: string) {
-    navigator.clipboard.writeText(subdomain);
-    toast({
-      title: 'Email was copied to clipboard',
-      position: 'bottom-right',
-      status: 'success',
-    });
-  }
 
   const isInputValid = searchText.length >= MIN_USERS_SEARCH_TEXT;
   const isLoading = navigation.state === 'submitting';
@@ -81,20 +70,7 @@ export default function UsersTable({ users, searchText }: UsersTableProps) {
               users.map((user) => {
                 return (
                   <Tr key={user.email}>
-                    <Td>
-                      <Flex justifyContent="space-between" alignItems="center">
-                        {user.email}
-                        <Tooltip label="Copy email to clipboard">
-                          <IconButton
-                            icon={<CopyIcon color="black" boxSize="5" />}
-                            variant="ghost"
-                            ml="2"
-                            onClick={() => onCopyNameToClipboard(user.email)}
-                            aria-label="copy email"
-                          />
-                        </Tooltip>
-                      </Flex>
-                    </Td>
+                    <Td>{user.email}</Td>
                     <Td>{user.displayName}</Td>
                     <Td>{user.dnsRecordCount}</Td>
                     <Td>

--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import {
   Flex,
   Box,
@@ -12,6 +13,7 @@ import {
   AccordionIcon,
   AccordionPanel,
   useToast,
+  useClipboard,
 } from '@chakra-ui/react';
 import { DownloadIcon, CopyIcon } from '@chakra-ui/icons';
 import { Link } from '@remix-run/react';
@@ -30,15 +32,17 @@ export default function CertificateDisplay({
   downloadPart,
 }: CertificateDisplayProps) {
   const toast = useToast();
+  const { onCopy, hasCopied } = useClipboard(value);
 
-  function onCopy() {
-    navigator.clipboard.writeText(value);
-    toast({
-      title: `${title} was copied to the clipboard`,
-      position: 'bottom-right',
-      status: 'success',
-    });
-  }
+  useEffect(() => {
+    if (hasCopied) {
+      toast({
+        title: `${title} was copied to the clipboard`,
+        position: 'bottom-right',
+        status: 'success',
+      });
+    }
+  }, [title, toast, hasCopied]);
 
   return (
     <Flex
@@ -62,7 +66,7 @@ export default function CertificateDisplay({
             }}
             aria-label={`Copy ${title}`}
             icon={<CopyIcon fontSize="md" />}
-            onClick={() => onCopy()}
+            onClick={onCopy}
           />
         </Tooltip>
         <Tooltip label={`Download ${title}`}>

--- a/app/components/dns-record-table-row.tsx
+++ b/app/components/dns-record-table-row.tsx
@@ -1,0 +1,125 @@
+import {
+  Tr,
+  Text,
+  Td,
+  IconButton,
+  Flex,
+  Tooltip,
+  HStack,
+  Link,
+  ButtonGroup,
+  useClipboard,
+} from '@chakra-ui/react';
+import { EditIcon, DeleteIcon, RepeatIcon, CopyIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import dayjs from 'dayjs';
+
+import { Form, useNavigate } from '@remix-run/react';
+import DnsRecordName from './dns-record/dns-record-name';
+import { useEffectiveUser } from '~/utils';
+
+import type { DnsRecord } from '@prisma/client';
+
+interface DnsRecordsTableRowProps {
+  dnsRecord: DnsRecord;
+  onDelete: (dnsRecord: DnsRecord) => void;
+  onCopied: () => void;
+}
+
+export default function DnsRecordsTableRow({
+  dnsRecord,
+  onDelete,
+  onCopied,
+}: DnsRecordsTableRowProps) {
+  const { baseDomain } = useEffectiveUser();
+  const { onCopy } = useClipboard(`${dnsRecord.subdomain}.${baseDomain}`);
+  const isRenewable = dayjs(dnsRecord.expiresAt).isBefore(dayjs().add(6, 'month'));
+  const navigate = useNavigate();
+
+  const handleOnCopy = () => {
+    onCopy();
+    onCopied();
+  };
+
+  return (
+    <Tr>
+      <Td>
+        <Flex justifyContent="space-between" alignItems="center">
+          <DnsRecordName dnsRecord={dnsRecord} baseDomain={baseDomain} />
+          <ButtonGroup>
+            <Link
+              href={`https://dnschecker.org/#${dnsRecord.type}/${dnsRecord.subdomain}.${baseDomain}`}
+              isExternal
+              target="_blank"
+            >
+              <Tooltip label="Check DNS record">
+                <IconButton
+                  icon={<InfoOutlineIcon color="black" boxSize="5" />}
+                  aria-label="Check DNS record"
+                  variant="ghost"
+                  ml="2"
+                />
+              </Tooltip>
+            </Link>
+            <Tooltip label="Copy DNS record to clipboard">
+              <IconButton
+                icon={<CopyIcon color="black" boxSize="5" />}
+                aria-label="Refresh DNS record"
+                variant="ghost"
+                ml="2"
+                onClick={handleOnCopy}
+              />
+            </Tooltip>
+          </ButtonGroup>
+        </Flex>
+      </Td>
+      <Td>{dnsRecord.type}</Td>
+      <Td>
+        <Tooltip label={dnsRecord.value}>
+          <Text isTruncated maxWidth="20ch">
+            {dnsRecord.value}
+          </Text>
+        </Tooltip>
+      </Td>
+      <Td>
+        <Flex alignItems="center">
+          {dnsRecord.expiresAt.toLocaleDateString('en-US')}
+          <Form method="patch" style={{ margin: 0 }}>
+            <input type="hidden" name="id" value={dnsRecord.id} />
+            <input type="hidden" name="intent" value="renew-dns-record" />
+            <Tooltip label="Renew DNS record">
+              <IconButton
+                icon={<RepeatIcon color="black" boxSize="5" />}
+                aria-label="Refresh DNS record"
+                variant="ghost"
+                type="submit"
+                isDisabled={!isRenewable}
+              />
+            </Tooltip>
+          </Form>
+        </Flex>
+      </Td>
+      <Td>
+        <HStack>
+          <Tooltip label="Edit DNS record">
+            <IconButton
+              onClick={() => navigate(dnsRecord.id.toString())}
+              icon={<EditIcon color="black" boxSize={5} />}
+              aria-label="Edit DNS record"
+              variant="ghost"
+              mr="1"
+            />
+          </Tooltip>
+          <Tooltip label="Delete DNS record">
+            <IconButton
+              onClick={() => onDelete(dnsRecord)}
+              icon={<DeleteIcon color="black" boxSize={5} />}
+              aria-label="Delete DNS record"
+              variant="ghost"
+              type="submit"
+            />
+          </Tooltip>
+        </HStack>
+      </Td>
+    </Tr>
+  );
+}


### PR DESCRIPTION
Fixes #535 

I've switched all our code over to use the [`useClipboard()` hook from Chakra-UI](https://chakra-ui.com/docs/hooks/use-clipboard).  To do it, I had to break some components up into smaller pieces, which was good anyway.

I've also removed the copy feature from the admin table, since you have to know the username to search for them anyway (I don't think it's necessary).

Finally, I got rid of the `useTransition()` hook, which is deprecated and changed to use [useNavigation()](https://remix.run/docs/en/main/pages/v2#usetransition). 