### PR TITLE
Improve instructions link on DNS record page,  form and DNS record Id

### DIFF
--- a/app/components/landing-page/landing-page-card.tsx
+++ b/app/components/landing-page/landing-page-card.tsx
@@ -38,11 +38,11 @@ export default function LandingPageCard({
           <Text>{cardDescription}</Text>
           {instructionsPath && (
             <Text>
-              To learn more, refer to{' '}
+              To learn more, refer to our{' '}
               <Link as={RemixLink} to={instructionsPath}>
                 {instructionsPath === '/certificate/information'
-                  ? 'our information page'
-                  : 'our instruction page'}
+                  ? 'information page'
+                  : 'instructions page'}
               </Link>
               .
             </Text>

--- a/app/routes/__index/dns-records/$dnsRecordId.tsx
+++ b/app/routes/__index/dns-records/$dnsRecordId.tsx
@@ -1,4 +1,4 @@
-import { Container, Heading, Text } from '@chakra-ui/react';
+import { Container, Heading, Text, Link } from '@chakra-ui/react';
 import { redirect, typedjson, useTypedLoaderData } from 'remix-typedjson';
 import { parseFormSafe } from 'zodix';
 import type { ActionArgs, LoaderArgs } from '@remix-run/node';
@@ -6,7 +6,7 @@ import DnsRecordForm from '~/components/dns-record/form';
 import { requireUser } from '~/session.server';
 import { getDnsRecordById, updateDnsRecordById } from '~/models/dns-record.server';
 import { isNameValid, UpdateDnsRecordSchema } from '~/lib/dns.server';
-import { useActionData, useCatch, useParams, Link } from '@remix-run/react';
+import { useActionData, useCatch, useParams, Link as RemixLink } from '@remix-run/react';
 import { buildDomain, getErrorMessageFromStatusCode } from '~/utils';
 import SeenErrorLayout from '~/components/errors/seen-error-layout';
 import UnseenErrorLayout from '~/components/errors/unseen-error-layout';
@@ -100,10 +100,8 @@ export default function DnsRecordRoute() {
         Choose a subdomain Name. This will be used to build your domain.
         <br /> (i.e. [subdomain].[username].mystudentproject.ca). <br />
         Then enter a Type and Value that will be mapped with your domain. For more info refer to our{' '}
-        <Link to={{ pathname: '/dns-records/instructions' }}>
-          <Text as="span" textDecoration="underline">
-            instructions page.
-          </Text>
+        <Link as={RemixLink} to={{ pathname: '/dns-records/instructions' }}>
+          instructions page.
         </Link>
       </Text>
       <DnsRecordForm errors={actionData} dnsRecord={dnsRecord} mode="EDIT" />

--- a/app/routes/__index/dns-records/index.tsx
+++ b/app/routes/__index/dns-records/index.tsx
@@ -1,6 +1,16 @@
 import { AddIcon } from '@chakra-ui/icons';
-import { Button, Center, Flex, Heading, Stat, StatLabel, StatNumber, Text } from '@chakra-ui/react';
-import { Link, useCatch } from '@remix-run/react';
+import {
+  Button,
+  Center,
+  Flex,
+  Heading,
+  Stat,
+  StatLabel,
+  StatNumber,
+  Text,
+  Link,
+} from '@chakra-ui/react';
+import { Link as RemixLink, useCatch } from '@remix-run/react';
 import { typedjson, useTypedLoaderData } from 'remix-typedjson';
 import { json } from '@remix-run/node';
 import { z } from 'zod';
@@ -117,10 +127,8 @@ export default function DnsRecordsIndexRoute() {
         into effect as your new domain needs to be spread in DNS servers around the globe. The
         expiration date is initially set to 6 months after the creation date and you can renew the
         DNS record using the renew button next to the expiry date. For more info refer to our{' '}
-        <Link to={{ pathname: '/dns-records/instructions' }}>
-          <Text as="span" textDecoration="underline">
-            instructions page.
-          </Text>
+        <Link as={RemixLink} to={{ pathname: '/dns-records/instructions' }}>
+          instructions page.
         </Link>
       </Text>
       {data.dnsRecords.length ? (
@@ -138,17 +146,17 @@ export default function DnsRecordsIndexRoute() {
                 {data.userDnsRecordCount} / {data.userDnsRecordLimit}
               </StatNumber>
             </Stat>
-            <Link to="/dns-records/new">
+            <RemixLink to="/dns-records/new">
               <Button rightIcon={<AddIcon boxSize={3} />}>Create new DNS Record</Button>
-            </Link>
+            </RemixLink>
           </Flex>
           <DnsRecordsTable dnsRecords={data.dnsRecords} />
         </>
       ) : (
         <Center mt="16">
-          <Link to="/dns-records/new">
+          <RemixLink to="/dns-records/new">
             <Button rightIcon={<AddIcon boxSize={3} />}>Create your first DNS Record!</Button>
-          </Link>
+          </RemixLink>
         </Center>
       )}
     </Flex>

--- a/app/routes/__index/dns-records/new.tsx
+++ b/app/routes/__index/dns-records/new.tsx
@@ -1,4 +1,4 @@
-import { Container, Heading, Text } from '@chakra-ui/react';
+import { Container, Heading, Text, Link } from '@chakra-ui/react';
 import { parseFormSafe } from 'zodix';
 import { redirect } from 'remix-typedjson';
 
@@ -8,7 +8,7 @@ import { createDnsRecord } from '~/models/dns-record.server';
 
 import type { ActionArgs } from '@remix-run/node';
 import { DnsRecordSchema, isNameValid } from '~/lib/dns.server';
-import { useActionData, Link } from '@remix-run/react';
+import { useActionData, Link as RemixLink } from '@remix-run/react';
 import { buildDomain } from '~/utils';
 
 export const action = async ({ request }: ActionArgs) => {
@@ -57,10 +57,8 @@ export default function NewDnsRecordRoute() {
         Choose a subdomain Name. This will be used to build your domain.
         <br /> (i.e. [subdomain].[username].mystudentproject.ca). <br />
         Then enter a Type and Value that will be mapped with your domain. For more info refer to our{' '}
-        <Link to={{ pathname: '/dns-records/instructions' }}>
-          <Text as="span" textDecoration="underline">
-            instructions page.
-          </Text>
+        <Link as={RemixLink} to={{ pathname: '/dns-records/instructions' }}>
+          instructions page.
         </Link>
       </Text>
       <DnsRecordForm errors={actionData} mode="CREATE" />

--- a/test/e2e/landing-page.spec.ts
+++ b/test/e2e/landing-page.spec.ts
@@ -23,7 +23,7 @@ test.describe('Landing Page', () => {
   });
 
   test('DNS Records Instructions Link', async ({ page }) => {
-    await page.getByRole('link', { name: 'our instruction page' }).click();
+    await page.getByRole('link', { name: 'instructions page' }).click();
 
     await expect(page).toHaveURL('/dns-records/instructions');
   });
@@ -35,7 +35,7 @@ test.describe('Landing Page', () => {
   });
 
   test('Certificate Instructions Link', async ({ page }) => {
-    await page.getByRole('link', { name: 'our information page' }).click();
+    await page.getByRole('link', { name: 'information page' }).click();
 
     await expect(page).toHaveURL('/certificate/information');
   });


### PR DESCRIPTION
Fixes #597

This PR changes the links in [dns-records/index](https://github.com/DevelopingSpace/starchart/blob/main/app/routes/__index/dns-records/index.tsx), [dns-records/new](https://github.com/DevelopingSpace/starchart/blob/main/app/routes/__index/dns-records/new.tsx), and [dns-records/$dnsRecordId](https://github.com/DevelopingSpace/starchart/blob/main/app/routes/__index/dns-records/%24dnsRecordId.tsx) (this last one is not included in the issue, but I thought it also needed fix) to be red and underlined.

![image](https://user-images.githubusercontent.com/23108901/231637370-130ddbdb-dd27-46f8-9ba7-6cded2ae92f8.png)

![image](https://user-images.githubusercontent.com/23108901/231637436-285a65c3-1aaa-46e0-b9de-c8f7721d8b66.png)


**Note**: I noticed that both _instruction_ and _instructions_ are used in links to the same page (the instructions page). 
![image](https://user-images.githubusercontent.com/23108901/231638336-fdf2b61d-5d81-4e7c-bb12-792919d7f054.png)

Should we make sure that we use the same word in all links? If so, I can make the change in this PR.
