### PR TITLE
Adding write content so that we can create the tag refs/tags/release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,6 +13,8 @@ jobs:
   Release:
     name: 'Release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: 'marvinpinto/action-automatic-releases@latest'
         with:


### PR DESCRIPTION
Not sure if this works (examples online might be using tokens with broader permissions idk I can't find much about this) but this should at least get us past current error as per the [list of git apis I have been looking at](https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#create-a-reference). We need the permissions to either create or patch a ref here otherwise we will get the current error.