### PR TITLE
fix: change 'Manage' to 'Create' dynamically on landing page

### DIFF
--- a/app/routes/__index/index.tsx
+++ b/app/routes/__index/index.tsx
@@ -1,14 +1,26 @@
 import { Flex, Text, VStack, Link, Heading } from '@chakra-ui/react';
+import { typedjson, useTypedLoaderData } from 'remix-typedjson';
 import type { LoaderArgs } from '@remix-run/node';
 
 import { requireUsername } from '~/session.server';
 import LandingPageCard from '~/components/landing-page/landing-page-card';
 import { useEffectiveUser } from '~/utils';
 
-export const loader = async ({ request }: LoaderArgs) => requireUsername(request);
+import { getDnsRecordCountByUsername } from '~/models/dns-record.server';
+import { getCertificateByUsername } from '~/models/certificate.server';
+
+export const loader = async ({ request }: LoaderArgs) => {
+  const username = await requireUsername(request);
+
+  return typedjson({
+    dnsRecordCount: await getDnsRecordCountByUsername(username),
+    mostRecentCertificate: await getCertificateByUsername(username),
+  });
+};
 
 export default function IndexRoute() {
   const user = useEffectiveUser();
+  const { dnsRecordCount, mostRecentCertificate } = useTypedLoaderData<typeof loader>();
 
   return (
     <VStack alignSelf="center">
@@ -49,14 +61,14 @@ export default function IndexRoute() {
         )}
         <LandingPageCard
           path="/dns-records"
-          pathName="Manage DNS Records"
+          pathName={dnsRecordCount > 0 ? 'Manage DNS Record' : 'Create DNS Record'}
           cardName="DNS Records"
           cardDescription="DNS Records are stored in Domain Name System (DNS) servers, which map a value to a domain name.  You can create a unique custom domain for each of your projects."
           instructionsPath="/dns-records/instructions"
         />
         <LandingPageCard
           path="/certificate"
-          pathName="Manage Certificate"
+          pathName={mostRecentCertificate ? 'Manage Certificate' : 'Create Certificate'}
           cardName="Certificate"
           cardDescription="An HTTPS Certificate allows a browser to establish a secure connection with your website. Any data between the client and your website will be encrypted and cannot be intercepted."
           instructionsPath="/certificate/information"


### PR DESCRIPTION
## Description
Resolves #599 by dynamically displaying "Create" or Manage" on the landing page based on the number of DNS records/Certificates associated with the authenticated user.

### Steps to test
- Run the project locally
- Notice the buttons labels
-  Request a new Certificate and DNS Record
- Navigate to the landing page
- Notice the button labels

https://user-images.githubusercontent.com/50856799/231910642-9cd7cd54-7f44-4eb9-a850-eb78a79780f8.mov

