### PR TITLE
Set USER_DNS_RECORD_LIMIT=10 on staging and production

### DIFF
--- a/docker-production.yml
+++ b/docker-production.yml
@@ -34,6 +34,7 @@ services:
       - PORT=8080
       - REDIS_URL=redis://redis:6379
       - ROOT_DOMAIN=mystudentproject.ca
+      - USER_DNS_RECORD_LIMIT=10
     secrets:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY

--- a/docker-staging.yml
+++ b/docker-staging.yml
@@ -36,6 +36,7 @@ services:
       - PORT=8080
       - REDIS_URL=redis://redis:6379
       - ROOT_DOMAIN=stage.mystudentproject.ca
+      - USER_DNS_RECORD_LIMIT=10
     secrets:
       - AWS_ACCESS_KEY_ID
       - AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION
Fixes #600

This sets a limit of 10 DNS Records per user on staging and production.  With 10,000 available records in Route53 hosted zones, this means max 1,000 users.  If it's too high/low, we can adjust later.