### PR TITLE
Fix DNS Record delete spec flakiness

### DIFF
--- a/test/e2e/dns-record-table.spec.ts
+++ b/test/e2e/dns-record-table.spec.ts
@@ -53,7 +53,10 @@ test.describe('authenticated as user', () => {
     const dnsRecordRow = page.locator('table tr').last();
     await dnsRecordRow.getByRole('button', { name: 'Delete DNS record' }).click();
     // Click on delete button in modal
-    await page.getByRole('button', { name: 'Delete' }).click();
+    const deleteModal = page
+      .locator('section')
+      .filter({ hasText: "Are you sure? You can't undo this action afterwards." });
+    await deleteModal.getByRole('button', { name: 'Delete' }).click();
     // Since there should be no DNS Records at this point, the table shouldn't exist
     await expect(page.locator('table')).toBeHidden();
   });


### PR DESCRIPTION
Fixes #618 

Made the modal delete button selector more specific so it doesn't pick up the DNS Record table delete button