### PR TITLE
Rework default tags for staging and production builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -349,13 +349,14 @@ jobs:
           build-args: |
             SAML_IDP_METADATA_PATH=./config/idp-metadata-staging.xml
           push: true
-          tags: ${{ env.IMAGE }}:sha-${{ env.GITHUB_SHA_SHORT }}, ${{ env.IMAGE }}:main, ${{ env.IMAGE }}:latest
+          tags: ${{ env.IMAGE }}:staging-sha-${{ env.GITHUB_SHA_SHORT }}, ${{ env.IMAGE }}:staging
 
       - name: Deploy to Staging via Webhook
         uses: navied/secure-actions-webhook@0.2.1
         env:
           HMAC_SECRET: ${{ secrets.WEBHOOK_STAGING_SECRET }}
+          TAG: staging-sha-${{ env.GITHUB_SHA_SHORT }}
         with:
           url: https://mycustomdomain-dev.senecacollege.ca/hooks/deploy
           hmacSecret: ${{ env.HMAC_SECRET }}
-          data: '{"tag": "sha-${{ env.GITHUB_SHA_SHORT }}"}'
+          data: '{"tag": "${{ env.TAG }}"}'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,13 +54,14 @@ jobs:
           build-args: |
             SAML_IDP_METADATA_PATH=./config/idp-metadata-production.xml
           push: true
-          tags: ${{ env.IMAGE }}:sha-${{ env.GITHUB_SHA_SHORT }}, ${{ env.IMAGE }}:release, ${{ env.IMAGE }}:latest
+          tags: ${{ env.IMAGE }}:production-sha-${{ env.GITHUB_SHA_SHORT }}, ${{ env.IMAGE }}:production
 
       - name: Deploy to Production via Webhook
         uses: navied/secure-actions-webhook@0.2.1
         env:
           HMAC_SECRET: ${{ secrets.WEBHOOK_PRODUCTION_SECRET }}
+          TAG: production-sha-${{ env.GITHUB_SHA_SHORT }}
         with:
           url: https://mycustomdomain.senecacollege.ca/hooks/deploy
           hmacSecret: ${{ env.HMAC_SECRET }}
-          data: '{"tag": "sha-${{ env.GITHUB_SHA_SHORT }}"}'
+          data: '{"tag": "${{ env.TAG }}"}'

--- a/docker-production.yml
+++ b/docker-production.yml
@@ -17,8 +17,8 @@ services:
         tag: redis
 
   mycustomdomain:
-    # Production runs the most recent release
-    image: ghcr.io/developingspace/starchart:release
+    # Production runs the most recent release built for production
+    image: ghcr.io/developingspace/starchart:production
     depends_on:
       - redis
     ports:

--- a/docker-staging.yml
+++ b/docker-staging.yml
@@ -17,8 +17,8 @@ services:
         tag: redis
 
   mycustomdomain:
-    # Staging runs the most recent commit on the main branch
-    image: ghcr.io/developingspace/starchart:main
+    # Staging runs the most recent commit on the main branch built for staging
+    image: ghcr.io/developingspace/starchart:staging
     depends_on:
       - redis
     ports:


### PR DESCRIPTION
I was updating production today, to use the latest database migrations, and I ran into an interesting bug.  You can't use an image built for staging to run on production, or vice-versa, due to how we bundle the SAML IdP metadata into the build.  An image for staging needs to be run on staging, and an image for production needs to be run on production.

This change updates our CI, docker tags, and docker-compose stack definitions to deal with this.  What we'll do now:

- in CI, build `staging*` images, and we'll use `staging` as our movable `latest` tag for staging
- in Release, build `production*` images, and we'll use `production` as our moveable `latest tag for production

We won't use `latest`, since it's not meaningful anymore, nor is `main`.

We need this in place before 1.0, and I need to update the stacks on staging and production manually to use them.