### PR TITLE
Reduce number of browsers we run in e2e tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,28 +58,11 @@ const config: PlaywrightTestConfig = {
       name: 'setup',
       testMatch: /.*\.setup\.ts/,
     },
-    {
-      name: 'chromium',
-      use: {
-        ...devices['Desktop Chrome'],
-      },
-      dependencies: ['setup'],
-      testIgnore: /.*\.mobile\.spec\.ts/,
-    },
 
     {
       name: 'firefox',
       use: {
         ...devices['Desktop Firefox'],
-      },
-      dependencies: ['setup'],
-      testIgnore: /.*\.mobile\.spec\.ts/,
-    },
-
-    {
-      name: 'webkit',
-      use: {
-        ...devices['Desktop Safari'],
       },
       dependencies: ['setup'],
       testIgnore: /.*\.mobile\.spec\.ts/,


### PR DESCRIPTION
Yesterday we were discussing the value of reducing the length of time our e2e tests take.  Doing so requires us to use fewer browsers in CI.

Here I'm using:

- Firefox (desktop)
- Chrome (desktop + mobile)
- Webkit (mobile)
- Edge (desktop)

The inclusion of Edge adds some degree of additional UI checks for a Chromium-based browser that has differences to Chrome.

Removing desktop Webkit (no one uses it, sorry Apple, much as I love you!), and Chromium vs. Chrome is not really helping us get more coverage.
