### PR TITLE
tag name => Release -> Latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
       - uses: 'marvinpinto/action-automatic-releases@latest'
         with:
           repo_token: '${{ secrets.GITHUB_TOKEN }}'
-          automatic_release_tag: 'release'
+          automatic_release_tag: 'latest'
           title: 'Change Log'
           prerelease: false
 


### PR DESCRIPTION
Fixes #654
Changed the name from release to latest to avoid confusion with the branch we push to right before using this action.

Tested using a repo I made that exhibited the same behavior with a release branch and tag named release that changed once the tag name was changed to "latest": 
https://github.com/sfrunza13/testingReleases
![image](https://user-images.githubusercontent.com/77400826/233476244-24c1115f-89a1-46ac-bce8-53da64b7ae22.png)
