### PR TITLE
Add bottom padding in dns instruction

### DIFF
--- a/app/routes/_auth.dns-records.instructions.tsx
+++ b/app/routes/_auth.dns-records.instructions.tsx
@@ -20,7 +20,7 @@ import FaqAccordion from '~/components/instructions/faq-accordion';
 
 export default function CertificateInstructionsRoute() {
   return (
-    <Flex flexDirection="column" maxWidth={750}>
+    <Flex flexDirection="column" paddingBottom="20" maxWidth={750}>
       <Heading as="h1" size={{ base: 'lg', md: 'xl' }} mt={{ base: 6, md: 12 }} mb="4">
         DNS Records
       </Heading>


### PR DESCRIPTION
Resolve #592 

Add the same bottom padding to DNS instruction as certificate information page. 