### PR TITLE
Use Chakra theme to style root elements

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -24,8 +24,6 @@ export const meta: V2_MetaFunction = () => [
 ];
 
 export const links: LinksFunction = () => [
-  // We want html and body to occupy the full window height for vertical centering
-  { rel: 'stylesheet', href: '/styles.css', type: 'text/css', as: 'style' },
   { rel: 'icon', href: '/favicon.ico', sizes: 'any' },
   { rel: 'manifest', href: '/manifest.json' },
 ];

--- a/app/theme/index.ts
+++ b/app/theme/index.ts
@@ -1,9 +1,11 @@
 import { defineStyleConfig, extendTheme, withDefaultColorScheme } from '@chakra-ui/react';
 import colors from './colors';
 import breakpoints from './breakpoints';
+import styles from './styles';
 
 const theme = extendTheme(
   {
+    styles,
     colors,
     breakpoints,
     components: {

--- a/app/theme/styles.ts
+++ b/app/theme/styles.ts
@@ -1,0 +1,14 @@
+// We want html and body to occupy the full window height for vertical centering
+const styles = {
+  global: {
+    html: {
+      height: '100%',
+    },
+    body: {
+      height: '100%',
+      minHeight: '100%',
+    },
+  },
+};
+
+export default styles;

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,7 +1,0 @@
-html {
-  height: 100%;
-}
-body {
-  height: 100%;
-  min-height: 100%;
-}


### PR DESCRIPTION
I was working on a PR in a different project, and noticed that you can style things globally via the Chakra theme.  This change converts the way we style `html` and `body`, using Chakra vs. `styles.css`.

See https://chakra-ui.com/docs/styled-system/global-styles