### PR TITLE
Fix padding issue on 'new' dns record route

### DIFF
--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -50,7 +50,7 @@ export default function CertificateDisplay({
       gap="4"
       textAlign={{ base: 'center', md: 'left' }}
       fontSize={{ base: 'sm', md: 'md' }}
-      paddingY="6"
+      paddingBottom={6}
     >
       <HStack gap="4" alignSelf={{ base: 'center', md: 'flex-start' }}>
         <Heading as="h4" size="sm">

--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -97,7 +97,7 @@ export default function CertificateDisplay({
         </Tooltip>
       </HStack>
       <Text>{description}</Text>
-      <Accordion allowMultiple>
+      <Accordion allowMultiple paddingY="6">
         <AccordionItem>
           <AccordionButton>
             <Box as="span" flex="1">

--- a/app/components/certificate/certificate-display.tsx
+++ b/app/components/certificate/certificate-display.tsx
@@ -50,6 +50,7 @@ export default function CertificateDisplay({
       gap="4"
       textAlign={{ base: 'center', md: 'left' }}
       fontSize={{ base: 'sm', md: 'md' }}
+      paddingY="6"
     >
       <HStack gap="4" alignSelf={{ base: 'center', md: 'flex-start' }}>
         <Heading as="h4" size="sm">
@@ -97,7 +98,7 @@ export default function CertificateDisplay({
         </Tooltip>
       </HStack>
       <Text>{description}</Text>
-      <Accordion allowMultiple paddingY="6">
+      <Accordion allowMultiple>
         <AccordionItem>
           <AccordionButton>
             <Box as="span" flex="1">

--- a/app/routes/_auth.dns-records.new.tsx
+++ b/app/routes/_auth.dns-records.new.tsx
@@ -49,7 +49,7 @@ export default function NewDnsRecordRoute() {
   const actionData = useActionData();
 
   return (
-    <Container maxW="container.xl">
+    <Container maxW="container.xl" paddingY="6">
       <Heading as="h1" size={{ base: 'lg', md: 'xl' }} mt={{ base: 6, md: 12 }}>
         Create new DNS Record
       </Heading>

--- a/app/routes/_auth.dns-records.new.tsx
+++ b/app/routes/_auth.dns-records.new.tsx
@@ -49,7 +49,7 @@ export default function NewDnsRecordRoute() {
   const actionData = useActionData();
 
   return (
-    <Container maxW="container.xl" paddingY="6">
+    <Container maxW="container.xl" paddingBottom="6">
       <Heading as="h1" size={{ base: 'lg', md: 'xl' }} mt={{ base: 6, md: 12 }}>
         Create new DNS Record
       </Heading>


### PR DESCRIPTION
## Description
This PR adds padding between the "Create" button on the New DNS Record route and the Footer. 

### Before
<img width="1319" alt="before screenshot 1" src="https://user-images.githubusercontent.com/50856799/233796484-ea8f4a33-2cb7-44de-835d-06ab1e933b35.png">
<img width="1319" alt="before screenshot 2" src="https://user-images.githubusercontent.com/50856799/233798198-0023b959-f771-41b8-8067-8e1b26df23b4.png">

### After
<img width="1319" alt="after screenshot 1" src="https://user-images.githubusercontent.com/50856799/233796492-6158b981-8c58-4779-b50e-79a0bc1a5083.png">
<img width="1319" alt="after screenshot 2" src="https://user-images.githubusercontent.com/50856799/233798156-cabacf8f-dbe1-46b2-b559-78ba845d3763.png">

