### PR TITLE
Bump playwright to 1.49.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -48,7 +48,7 @@
         "zodix": "^0.4.1"
       },
       "devDependencies": {
-        "@playwright/test": "^1.35.0",
+        "@playwright/test": "^1.49.1",
         "@remix-run/dev": "^1.16.1",
         "@remix-run/eslint-config": "^1.16.1",
         "@types/bad-words": "^3.0.1",
@@ -5395,22 +5395,19 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.35.0.tgz",
-      "integrity": "sha512-6qXdd5edCBynOwsz1YcNfgX8tNWeuS9fxy5o59D0rvHXxRtjXRebB4gE4vFVfEMXl/z8zTnAzfOs7aQDEs8G4Q==",
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.49.1.tgz",
+      "integrity": "sha512-Ky+BVzPz8pL6PQxHqNRW1k3mIyv933LML7HktS8uik0bUXNCdPhoS/kLihiO1tMf/egaJb4IutXd7UywvXEW+g==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@types/node": "*",
-        "playwright-core": "1.35.0"
+        "playwright": "1.49.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=16"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -15789,16 +15786,36 @@
         "pathe": "^1.1.0"
       }
     },
-    "node_modules/playwright-core": {
-      "version": "1.35.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.35.0.tgz",
-      "integrity": "sha512-muMXyPmIx/2DPrCHOD1H1ePT01o7OdKxKj2ebmCAYvqhUy+Y1bpal7B0rdoxros7YrXI294JT/DWw2LqyiqTPA==",
+    "node_modules/playwright": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.49.1.tgz",
+      "integrity": "sha512-VYL8zLoNTBxVOrJBbDuRgDWa3i+mfQgDTrL8Ah9QXZ7ax4Dsj0MSq5bYgytRnDVVe+njoKnfsYkH3HzqVj5UZA==",
       "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.49.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.49.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.49.1.tgz",
+      "integrity": "sha512-BzmpVcs4kE2CH15rWfzpjzVGhWERJfmnXmniSyKeRZUs9Ws65m+RGIi7mjJK/euCegfn3i7jvqWeWyHe9y3Vgg==",
+      "dev": true,
+      "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=18"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "zodix": "^0.4.1"
   },
   "devDependencies": {
-    "@playwright/test": "^1.35.0",
+    "@playwright/test": "^1.49.1",
     "@remix-run/dev": "^1.16.1",
     "@remix-run/eslint-config": "^1.16.1",
     "@types/bad-words": "^3.0.1",


### PR DESCRIPTION
Playwright install is failing in CI (E2E Tests). Bumping playwright version should fix that.

Ref: 
![Installation error log](https://github.com/user-attachments/assets/c7099f90-c354-4f41-94d9-4d510e74a779)
