### PR TITLE
Fix invalid value for VSCode workspace setting "source.fixAll"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,7 +2,7 @@
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.codeActionsOnSave": {
-    "source.fixAll": true
+    "source.fixAll": "explicit"
   },
   "files.eol": "\n",
   "files.insertFinalNewline": true,


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1219348f-9663-48da-9def-fd78db468e89)
