### PR TITLE
Rename lint jobs to be linter-agnostic

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -244,7 +244,7 @@ jobs:
         with:
           dockerfile: Dockerfile
 
-  ESLint:
+  Lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -270,7 +270,7 @@ jobs:
         if: steps.node_modules-cache-restore.outputs.cache-hit != 'true'
         run: npm ci
 
-      - name: eslint check
+      - name: Lint
         run: npm run lint
 
       - name: Cache node_modules
@@ -326,7 +326,7 @@ jobs:
     if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
     runs-on: ubuntu-latest
     # Don't bother unless everything else passes
-    needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, ESLint, Type-Check]
+    needs: [Build, Prettier, Unit-Tests, E2E-Tests, Dockerfile-Lint, Lint, Type-Check]
     env:
       IMAGE: ghcr.io/developingspace/starchart
     permissions:


### PR DESCRIPTION
We should remove any references to ESLint from CI since we dropped ESLint.