### PR TITLE
Move mysql and redis bind mounts to /docker/volumes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,7 @@
 /.vscode
 /img
 /e2e/
-/mysql-data
+/docker/volumes
 /node_modules
 /playwright-report
 /test

--- a/.gitignore
+++ b/.gitignore
@@ -4,8 +4,7 @@ node_modules
 /public/build
 .env
 
-/redis-data
-/mysql-data
+/docker/volumes/
 /test-results/
 /playwright-report/
 /playwright/.cache/

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -4,8 +4,7 @@
     "node_modules/**",
     "build/**",
     "public/build/**",
-    "mysql-data/**",
-    "redis-data/**",
+    "docker/volumes/**",
     "img/**",
     "dev-secrets/**",
     "playwright-report/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,7 @@ $ npm run db:studio:test
 docker compose down
 ```
 
-> **Note** `npm run setup` creates a local `mysql-data/` directory, and is a one time setup. That directory can be safely deleted if the database needs to be reset, or if errors occur during database startup.
+> **Note** `npm run setup` creates a local `docker/volumes/mysql-data/` directory, and is a one time setup. That directory can be safely deleted if the database needs to be reset, or if errors occur during database startup.
 
 > **Note** `npm run build` needs to be executed the first time running the project. As it generates a `build/server.js` script that `npm run dev` depends on. Subsequent times, only `npm run dev` is needed to run the app in development mode.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
       # Only for dev
       - 3306:3306
     volumes:
-      # Persist data to ./mysql-data. Remove if you want to clear the db.
-      - ./mysql-data:/var/lib/mysql
+      # Persist data to ./docker/volumes/mysql-data. Remove if you want to clear the db.
+      - ./docker/volumes/mysql-data:/var/lib/mysql
       # Locate SQL file to setup test database
       - ./config/01-databases.sql:/docker-entrypoint-initdb.d/init/01-databases.sql
     environment:
@@ -27,8 +27,8 @@ services:
       # Only for dev
       - 6379:6379
     volumes:
-      # Persist data to ./redis-data. Remove if you want to clear the db.
-      - ./redis-data:/data
+      # Persist data to ./docker/volumes/redis-data. Remove if you want to clear the db.
+      - ./docker/volumes/redis-data:/data
 
   # Mock Route53 server for testing, see:
   # http://docs.getmoto.org/en/latest/docs/server_mode.html

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
     globals: true,
     setupFiles: ['./test/unit/setup-test-env.ts'],
     include: ['./test/unit/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
-    watchExclude: ['.*\\/node_modules\\/.*', '.*\\/build\\/.*', '.*\\/mysql-data\\/.*'],
+    watchExclude: ['.*\\/node_modules\\/.*', '.*\\/build\\/.*', '.*\\/docker\\/volumes\\/.*'],
     coverage: {
       provider: 'istanbul',
     },


### PR DESCRIPTION
This aims to make the project root directory a bit more organized by moving all bind mounts under a single directory.