### PR TITLE
Improve DNS record type handling

### DIFF
--- a/services/reconciler/Route53CompareStructureGenerator.server.ts
+++ b/services/reconciler/Route53CompareStructureGenerator.server.ts
@@ -1,7 +1,7 @@
 import { set } from 'lodash';
 
 import { getDnsRecordSetPage } from './route53-client.server';
-import { fromRoute53RecordValue } from './route53Utils.server';
+import { fromRoute53RecordValue, isSupportedDnsRecordType } from './route53Utils.server';
 
 // Using this in JS code later, cannot `import type`
 import { DnsRecordType } from '@prisma/client';
@@ -31,7 +31,7 @@ class Route53CompareStructureGenerator {
 
       // We only care about record types that we handle. NS, SOA, etc. should be ignored
       // RecordSet.Type is given as `string`, so we have to do this for TS to compare them
-      if (!Object.values(DnsRecordType).includes(recordSet.Type as DnsRecordType)) {
+      if (isSupportedDnsRecordType(recordSet.Type)) {
         return;
       }
 

--- a/services/reconciler/createChangeSetFromCompareStructures.server.ts
+++ b/services/reconciler/createChangeSetFromCompareStructures.server.ts
@@ -5,7 +5,7 @@ import { DnsRecordType } from '@prisma/client';
 
 import { Change, ChangeAction } from '@aws-sdk/client-route-53';
 import type { ReconcilerCompareStructure } from './ReconcilerTypes';
-import { toRoute53RecordValue, toRoute53RRType } from './route53Utils.server';
+import { toRoute53RecordValue } from './route53Utils.server';
 
 interface CompareStructures {
   dbStructure: ReconcilerCompareStructure;
@@ -36,7 +36,7 @@ export const createRemovedChangeSetFromCompareStructures = ({
         Action: ChangeAction.DELETE,
         ResourceRecordSet: {
           Name: fqdn,
-          Type: toRoute53RRType(type),
+          Type: type,
           ResourceRecords: route53Value.map((value) => ({
             // Convert to special Route53 TXT record format. Details in route53Utils.server.ts
             Value: toRoute53RecordValue(type as DnsRecordType, value),

--- a/services/reconciler/createChangeSetFromCompareStructures.server.ts
+++ b/services/reconciler/createChangeSetFromCompareStructures.server.ts
@@ -71,19 +71,14 @@ export const createUpsertedChangeSetFromCompareStructures = ({
       }
 
       /**
-       * https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-multivalue.html
+       * https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-multivalue.html#rrsets-values-multivalue-type
        *
-       * According to the above, only A, AAAA, CAA, MX, NAPTR, PTR, SPF, SRV and TXT records can be multi-value
+       * According to the above, NS and CNAME records cant be multi-value
        */
 
-      if (
-        dbValue.length > 1 &&
-        !([DnsRecordType.A, DnsRecordType.AAAA, DnsRecordType.TXT] as DnsRecordType[]).includes(
-          type as DnsRecordType
-        )
-      ) {
+      if (dbValue.length > 1 && (type == 'NS' || type == 'CNAME')) {
         logger.error(
-          'Error creating DNS changeset Only A, AAAA and TXT records can be multivalue. Ignoring records',
+          'Error creating DNS changeset NS and CNAME records cannot be multi-value. Ignoring records',
           { fqdn, type }
         );
         return;

--- a/services/reconciler/createChangeSetFromCompareStructures.server.ts
+++ b/services/reconciler/createChangeSetFromCompareStructures.server.ts
@@ -36,7 +36,7 @@ export const createRemovedChangeSetFromCompareStructures = ({
         Action: ChangeAction.DELETE,
         ResourceRecordSet: {
           Name: fqdn,
-          Type: type,
+          Type: type as DnsRecordType,
           ResourceRecords: route53Value.map((value) => ({
             // Convert to special Route53 TXT record format. Details in route53Utils.server.ts
             Value: toRoute53RecordValue(type as DnsRecordType, value),
@@ -93,7 +93,7 @@ export const createUpsertedChangeSetFromCompareStructures = ({
         Action: ChangeAction.UPSERT,
         ResourceRecordSet: {
           Name: fqdn,
-          Type: toRoute53RRType(type),
+          Type: type as DnsRecordType,
           ResourceRecords: dbValue.map((value) => ({
             // Convert to special Route53 TXT record format. Details in route53Utils.server.ts
             Value: toRoute53RecordValue(type as DnsRecordType, value),

--- a/services/reconciler/route53-client.server.ts
+++ b/services/reconciler/route53-client.server.ts
@@ -14,7 +14,6 @@ import type {
   ListResourceRecordSetsResponse,
   Change,
 } from '@aws-sdk/client-route-53';
-import { toRoute53RRType } from './route53Utils.server';
 
 const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = secrets;
 const { NODE_ENV } = process.env;
@@ -127,7 +126,7 @@ export const getDnsRecordSetPage = async (
     const command = new ListResourceRecordSetsCommand({
       HostedZoneId: await getHostedZoneId(),
       StartRecordName: fqdn,
-      StartRecordType: type ? toRoute53RRType(type) : undefined,
+      StartRecordType: type,
     });
 
     return route53Client.send(command);

--- a/services/reconciler/route53-client.server.ts
+++ b/services/reconciler/route53-client.server.ts
@@ -119,8 +119,7 @@ export async function createHostedZone(domain: string) {
  */
 export const getDnsRecordSetPage = async (
   fqdn?: string,
-  // Using string as it cam be any record type not just the ones we use, also AWS sdk refers to it as string
-  type?: string
+  type?: RRType
 ): Promise<ListResourceRecordSetsResponse> => {
   try {
     const command = new ListResourceRecordSetsCommand({

--- a/services/reconciler/route53-client.server.ts
+++ b/services/reconciler/route53-client.server.ts
@@ -3,17 +3,15 @@ import {
   CreateHostedZoneCommand,
   ChangeResourceRecordSetsCommand,
   ListResourceRecordSetsCommand,
-} from '@aws-sdk/client-route-53';
-
-import logger from '~/lib/logger.server';
-import secrets from '~/lib/secrets.server';
-
-import type {
   CreateHostedZoneResponse,
   ChangeResourceRecordSetsResponse,
   ListResourceRecordSetsResponse,
   Change,
+  RRType,
 } from '@aws-sdk/client-route-53';
+
+import logger from '~/lib/logger.server';
+import secrets from '~/lib/secrets.server';
 
 const { AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY } = secrets;
 const { NODE_ENV } = process.env;

--- a/services/reconciler/route53Utils.server.ts
+++ b/services/reconciler/route53Utils.server.ts
@@ -76,3 +76,7 @@ export const fromRoute53RecordValue = (type: DnsRecordType, value: string): stri
 
   return segments.join('');
 };
+
+export function isSupportedDnsRecordType(type: string): type is DnsRecordType {
+  return Object.keys(DnsRecordType).includes(type);
+}

--- a/services/reconciler/route53Utils.server.ts
+++ b/services/reconciler/route53Utils.server.ts
@@ -1,5 +1,4 @@
 import { DnsRecordType } from '@prisma/client';
-import { RRType } from '@aws-sdk/client-route-53';
 
 /**
  * We need to use some special structures when sending / receiving recordSets
@@ -76,29 +75,4 @@ export const fromRoute53RecordValue = (type: DnsRecordType, value: string): stri
     .map((segment) => segment.replace(/\\(\d{3}|\\|")/g, unescapeFn));
 
   return segments.join('');
-};
-
-export const toRoute53RRType = (type: string): RRType => {
-  switch (type) {
-    case 'A':
-    case 'AAAA':
-    case 'CAA':
-    case 'CNAME':
-    case 'DS':
-    case 'HTTPS':
-    case 'MX':
-    case 'NAPTR':
-    case 'NS':
-    case 'PTR':
-    case 'SOA':
-    case 'SPF':
-    case 'SRV':
-    case 'SSHFP':
-    case 'SVCB':
-    case 'TLSA':
-    case 'TXT':
-      return type;
-    default:
-      throw new Error(`Invalid RRType: ${type}`);
-  }
 };


### PR DESCRIPTION
Follow-up on #830.

In #830, there was discussion on using a function to map `type` to `RRType` instead of using `type as RRType`: https://github.com/DevelopingSpace/starchart/pull/830#pullrequestreview-2613283520

Earlier in the code, we're already asserting `type as DnsRecordType`, which is a subset of `RRType`. I think it makes sense to be consistent and use `type as DnsRecordType` here too.

Also in services/reconciler/route53-client.server.ts > getDnsRecordSetPage(), we can set the type of the `type` parameter to RRType so we don't need to map it later.

Unrelated changes:

- Simplified the logic for handling multi-value records to blacklist types that disallow them (there are only two) instead of whitelisting types that allow them, of which new ones have been added to Route53.
- Cleaned up imports in services/reconciler/route53-client.server.ts