### PR TITLE
Add ability to handle MX records

### DIFF
--- a/app/components/dns-record/form.tsx
+++ b/app/components/dns-record/form.tsx
@@ -47,13 +47,14 @@ export default function DnsRecordForm({ dnsRecord, mode, errors }: dnsRecordForm
         <FormField
           label="Type"
           isRequired={true}
-          helpText="DNS Record Type (IPv4, IPv6, Domain Name, Text) indicates what Value will be"
+          helpText="DNS Record Type (IPv4, IPv6, Domain Name, Mail Server, Text) indicates what Value will be"
           error={errors?.fieldErrors.type?.join(' ')}
         >
           <Select placeholder="Select a type" name="type" defaultValue={dnsRecord?.type}>
             <option value="A">A Record (IPv4 Address)</option>
             <option value="AAAA">AAAA Record (IPv6 Address)</option>
             <option value="CNAME">CNAME Record (Domain Name)</option>
+            <option value="MX">MX Record (Mail Server)</option>
             <option value="TXT">TXT Record (Text Value)</option>
           </Select>
         </FormField>
@@ -61,7 +62,7 @@ export default function DnsRecordForm({ dnsRecord, mode, errors }: dnsRecordForm
         <FormField
           label="Value"
           isRequired={true}
-          helpText="Value must match Type: A=IPv4, AAAA=IPv6, CNAME=domain.com, TXT=any text..."
+          helpText="Value must match Type: A=IPv4, AAAA=IPv6, CNAME=domain.com, MX=domain.com, TXT=any text..."
           error={errors?.fieldErrors.value?.join(' ')}
         >
           <Input name="value" defaultValue={dnsRecord?.value} />

--- a/app/lib/dns.server.ts
+++ b/app/lib/dns.server.ts
@@ -60,6 +60,11 @@ export const isValueValid = (type: DnsRecordType, value: string) => {
     return !isIPRange(value) && isFQDN(value);
   }
 
+  // Same rule as CNAME
+  if (type === 'MX') {
+    return !isIPRange(value) && isFQDN(value);
+  }
+
   if (type === 'TXT') {
     // TXT records must be less than 4000, and we won't bother with empty
     return value.length > 0 && value.length <= 4000;

--- a/app/routes/_auth.dns-records.instructions.tsx
+++ b/app/routes/_auth.dns-records.instructions.tsx
@@ -53,6 +53,9 @@ export default function CertificateInstructionsRoute() {
                 <Text fontWeight="medium">CNAME Record</Text>
               </Tab>
               <Tab>
+                <Text fontWeight="medium">MX Record</Text>
+              </Tab>
+              <Tab>
                 <Text fontWeight="medium">TXT Record</Text>
               </Tab>
             </TabList>
@@ -111,6 +114,31 @@ export default function CertificateInstructionsRoute() {
                   When creating a CNAME record, remember to only include the domain name in the
                   value field. Including other parts of a URL, such as "https://" or a trailing "/",
                   can cause the CNAME record to fail to resolve correctly.
+                </Text>
+              </TabPanel>
+              <TabPanel>
+                <Text>
+                  <Text as="span" fontWeight="bold">
+                    Purpose:{' '}
+                  </Text>
+                  Directs email to a mail server.
+                </Text>
+                <Text>
+                  <Text as="span" fontWeight="bold">
+                    Example:{' '}
+                  </Text>
+                  Your project's domain name is "my-project.user.mystudentproject.ca", and you have
+                  a mail server running at "mail.my-mail-server.com". You wish people to contact you
+                  at "@my-project.user.mystudentproject.ca". Create an MX record that maps
+                  "my-project.user.mystudentproject.ca" to "mail.my-mail-server.com".
+                </Text>
+                <Text>
+                  <Text as="span" fontWeight="bold">
+                    Note:{' '}
+                  </Text>
+                  An MX record has to point to an A or AAAA record, while pointing to a CNAME is
+                  forbidden. In the example above, "mail.my-mail-server.com" has to be an A or AAAA
+                  record.
                 </Text>
               </TabPanel>
               <TabPanel>

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -77,6 +77,7 @@ enum DnsRecordType {
   A
   AAAA
   CNAME
+  MX
   TXT
 }
 

--- a/services/reconciler/route53Utils.server.ts
+++ b/services/reconciler/route53Utils.server.ts
@@ -40,6 +40,13 @@ const unescapeFn = (_: string, selection: string): string => {
 };
 
 export const toRoute53RecordValue = (type: DnsRecordType, value: string): string => {
+  /* Route 53 expects priority in the value of each MX record
+   * Using 10 as a default since we don't handle priority in this project
+   */
+  if (type === DnsRecordType.MX) {
+    return '10 ' + value;
+  }
+
   if (type !== DnsRecordType.TXT) {
     return value;
   }
@@ -60,6 +67,11 @@ export const toRoute53RecordValue = (type: DnsRecordType, value: string): string
 };
 
 export const fromRoute53RecordValue = (type: DnsRecordType, value: string): string => {
+  // Route 53 contains priority in the value of each MX record
+  if (type === DnsRecordType.MX) {
+    return value.split(' ')[1];
+  }
+
   if (type !== DnsRecordType.TXT) {
     return value;
   }

--- a/test/unit/dns.server.test.ts
+++ b/test/unit/dns.server.test.ts
@@ -65,6 +65,11 @@ describe('DNS server lib function test', () => {
     expect(isValueValid(DnsRecordType.CNAME, '2001:db8:3333:4444:5555:6666:7777:8888')).toBe(false);
     expect(isValueValid(DnsRecordType.CNAME, 'improper-domain')).toBe(false);
     expect(isValueValid(DnsRecordType.CNAME, 'improper_domain.com')).toBe(false);
+    expect(isValueValid(DnsRecordType.MX, '')).toBe(false);
+    expect(isValueValid(DnsRecordType.MX, '192.168.0.0')).toBe(false);
+    expect(isValueValid(DnsRecordType.MX, '2001:db8:3333:4444:5555:6666:7777:8888')).toBe(false);
+    expect(isValueValid(DnsRecordType.MX, 'improper-domain')).toBe(false);
+    expect(isValueValid(DnsRecordType.MX, 'improper_domain.com')).toBe(false);
     expect(isValueValid(DnsRecordType.TXT, '')).toBe(false);
   });
 });

--- a/test/unit/dns.server.test.ts
+++ b/test/unit/dns.server.test.ts
@@ -51,6 +51,7 @@ describe('DNS server lib function test', () => {
     expect(isValueValid(DnsRecordType.AAAA, '2001:db8:3333:4444:5555:6666:7777:8888')).toBe(true);
     expect(isValueValid(DnsRecordType.AAAA, 'a:b:c:d:e:f:0:1')).toBe(true);
     expect(isValueValid(DnsRecordType.CNAME, 'proper-domain.com')).toBe(true);
+    expect(isValueValid(DnsRecordType.MX, 'mail.example.com')).toBe(true);
     expect(isValueValid(DnsRecordType.TXT, 'any text')).toBe(true);
 
     expect(isValueValid(DnsRecordType.A, '192.168.0')).toBe(false);

--- a/test/unit/route53-client.server.test.ts
+++ b/test/unit/route53-client.server.test.ts
@@ -82,6 +82,15 @@ describe('Route53 Client functions test', () => {
         Action: ChangeAction.UPSERT,
         ResourceRecordSet: {
           Name: fqdn(),
+          ResourceRecords: [{ Value: '10 mail.example.com' }],
+          TTL: 300,
+          Type: RRType.MX,
+        },
+      },
+      {
+        Action: ChangeAction.UPSERT,
+        ResourceRecordSet: {
+          Name: fqdn(),
           ResourceRecords: [{ Value: '"hello world"' }],
           TTL: 300,
           Type: RRType.TXT,

--- a/test/unit/route53.server.test.ts
+++ b/test/unit/route53.server.test.ts
@@ -11,6 +11,12 @@ describe('Route53 functionality test raw => Route53 format', () => {
     expect(result).toEqual('1.2.3.4');
   });
 
+  test('Handles an MX record', () => {
+    const result = toRoute53RecordValue(DnsRecordType.MX, 'mail.example.com');
+
+    expect(result).toEqual('10 mail.example.com');
+  });
+
   test('Handles input with no special chars, and < 255 length', () => {
     // Adding characters from the edge of range
     const result = toRoute53RecordValue(DnsRecordType.TXT, '!Hello~');
@@ -58,6 +64,12 @@ describe('Route53 functionality test Route53 => raw format', () => {
     const result = fromRoute53RecordValue(DnsRecordType.A, '1.2.3.4');
 
     expect(result).toEqual('1.2.3.4');
+  });
+
+  test('Handles an MX record', () => {
+    const result = fromRoute53RecordValue(DnsRecordType.MX, '10 mail.example.com');
+
+    expect(result).toEqual('mail.example.com');
   });
 
   test('Handles input with no special chars, and < 255 length', () => {


### PR DESCRIPTION
Closes #787.

### Description
This PR implements the feature to manage MX records. It also includes relevant unit tests and a new section in the instructions page.

### References
- [Supported DNS record types - MX record type](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/ResourceRecordTypes.html#MXFormat)
- [RFC 2181 - 10.3. MX and NS records](https://datatracker.ietf.org/doc/html/rfc2181#section-10.3)