### PR TITLE
Fix certificate content

### DIFF
--- a/app/models/certificate.server.ts
+++ b/app/models/certificate.server.ts
@@ -7,7 +7,7 @@ export type CertificateWithFullChain = Certificate & { fullChain?: string };
 // If we have the certificate and chain, use them to add the fullChain
 function computeFullChain(certificate: Certificate): CertificateWithFullChain {
   return certificate?.certificate && certificate?.chain
-    ? { ...certificate, fullChain: `${certificate.certificate}${certificate.chain}` }
+    ? { ...certificate, fullChain: `${certificate.certificate}\n${certificate.chain}` }
     : certificate;
 }
 

--- a/app/routes/_auth.certificate.download.$part.ts
+++ b/app/routes/_auth.certificate.download.$part.ts
@@ -39,9 +39,9 @@ export async function loader({ request, params }: LoaderFunctionArgs) {
       case 'privateKey':
         return createResponse(certificate.privateKey, `${certificate.domain}.privkey.pem`);
       case 'chain':
-        return createResponse(certificate.certificate, `${certificate.domain}.chain.pem`);
+        return createResponse(certificate.chain, `${certificate.domain}.chain.pem`);
       case 'fullChain':
-        return createResponse(certificate.certificate, `${certificate.domain}.bundle.pem`);
+        return createResponse(certificate.fullChain!, `${certificate.domain}.bundle.pem`);
       default:
         throw new Response(`Unknown certificate part: ${params.part}`, { status: 400 });
     }


### PR DESCRIPTION
Closes #856.

### Description
This PR fixes the download handler for TLS certificates. It also adds a new line in between entities inside a full chain certificate to get rid of the overlap:

#### Before
```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE----------BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```
#### After
```
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
-----BEGIN CERTIFICATE-----
...
-----END CERTIFICATE-----
```