### PR TITLE
Fix failing docker build: @esbuild/linux-x64 could not be found

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,17 +21,7 @@ FROM base AS deps
 
 WORKDIR /app
 COPY package*.json .npmrc ./
-RUN npm ci --include=dev --ignore-scripts
-
-###############################################################################
-
-# Remove any non-production dependencies
-FROM base AS production-deps
-
-WORKDIR /app
-COPY --from=deps /app/node_modules ./node_modules
-COPY package*.json .npmrc ./
-RUN npm prune --omit=dev
+RUN npm ci --include=dev
 
 ###############################################################################
 
@@ -47,6 +37,18 @@ ENV DATABASE_URL="mysql://user:password@localhost:3306/starchart"
 
 RUN npx prisma generate \
   && npm run build
+
+###############################################################################
+
+# Remove any non-production dependencies
+FROM base AS production-deps
+
+WORKDIR /app
+COPY --from=deps /app/node_modules ./node_modules
+COPY package*.json .npmrc ./
+RUN npm prune --omit=dev
+
+###############################################################################
 
 # Deploy the built app on top of the production deps, run as non-root
 FROM base AS deploy


### PR DESCRIPTION
Fixing failure in docker build and deploy:

```
#14 2.737 > @senecacdot/starchart@1.0.0 build:remix
#14 2.737 > remix build
#14 2.737 
#14 3.543 [info] building... (NODE_ENV=production)
#14 3.561 [warn] Fetcher persistence behavior is changing in React Router v7
#14 3.561 ┃ You can use the `v3_fetcherPersist` future flag to opt-in early.
#14 3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_fetcherPersist
#14 3.561 ┗
#14 3.561 [warn] Route discovery/manifest behavior is changing in React Router v7
#14 3.561 ┃ You can use the `v3_lazyRouteDiscovery` future flag to opt-in early.
#14 3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_lazyRouteDiscovery
#14 3.561 ┗
#14 3.561 [warn] Relative routing behavior for splat routes is changing in React Router v7
#14 3.561 ┃ You can use the `v3_relativeSplatPath` future flag to opt-in early.
#14 3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_relativeSplatPath
#14 3.561 ┗
#14 3.561 [warn] Data fetching is changing to a single fetch in React Router v7
#14 3.561 ┃ You can use the `v3_singleFetch` future flag to opt-in early.
#14 3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_singleFetch
#14 3.561 ┗
#14 3.561 [warn] The format of errors thrown on aborted requests is changing in React Router v7
#14 3.561 ┃ You can use the `v3_throwAbortReason` future flag to opt-in early.
#14 3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_throwAbortReason
#14 3.561 ┗
#14 3.565 The package "@esbuild/linux-x64" could not be found, and is needed by esbuild.
#14 3.565 
#14 3.565 If you are installing esbuild with npm, make sure that you don't specify the
#14 3.565 "--no-optional" or "--omit=optional" flags. The "optionalDependencies" feature
#14 3.565 of "package.json" is used by esbuild to install the correct binary executable
#14 3.565 for your current platform.
#14 3.581 ERROR: "build:remix" exited with 1.
#14 ERROR: process "/bin/sh -c npx prisma generate   && npm run build" did not complete successfully: exit code: 1
#15 [production-deps 4/4] RUN npm prune --omit=dev
#15 CANCELED
------
 > [build 4/4] RUN npx prisma generate   && npm run build:
3.561 ┃ You can use the `v3_throwAbortReason` future flag to opt-in early.
3.561 ┃ -> https://remix.run/docs/en/2.13.1/start/future-flags#v3_throwAbortReason
3.561 ┗
3.565 The package "@esbuild/linux-x64" could not be found, and is needed by esbuild.
3.565 
3.565 If you are installing esbuild with npm, make sure that you don't specify the
3.565 "--no-optional" or "--omit=optional" flags. The "optionalDependencies" feature
3.565 of "package.json" is used by esbuild to install the correct binary executable
3.565 for your current platform.
3.581 ERROR: "build:remix" exited with 1.
------
 1 warning found (use docker --debug to expand):
 - UndefinedVar: Usage of undefined variable '$LOG_LEVEL' (line 55)
Dockerfile:48
--------------------
  47 |     
  48 | >>> RUN npx prisma generate \
  49 | >>>   && npm run build
  50 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c npx prisma generate   && npm run build" did not complete successfully: exit code: 1

```