### PR TITLE
Don't parse database url before passing to prisma

### DIFF
--- a/app/db.server.ts
+++ b/app/db.server.ts
@@ -34,18 +34,9 @@ function getClient() {
     throw new Error('DATABASE_URL secret not set');
   }
 
-  const databaseUrl = new URL(DATABASE_URL);
+  logger.info(`🔌 setting up prisma client to ${new URL(DATABASE_URL).host}`);
 
-  logger.info(`🔌 setting up prisma client to ${databaseUrl.host}`);
-
-  const adapter = new PrismaMariaDb({
-    host: databaseUrl.hostname,
-    port: parseInt(databaseUrl.port || '3306'),
-    user: databaseUrl.username,
-    password: databaseUrl.password,
-    database: databaseUrl.pathname.slice(1), // Remove leading '/'
-    connectionLimit: 5,
-  });
+  const adapter = new PrismaMariaDb(DATABASE_URL);
 
   // NOTE: during development if you change anything in this function, remember
   // that this only runs once per server restart and won't automatically be
@@ -54,10 +45,7 @@ function getClient() {
   const client = new PrismaClient({ adapter });
 
   // connect eagerly
-  client
-    .$connect()
-    .then(() => console.debug('✅ Prisma connected successfully'))
-    .catch((err) => console.error('❌ Prisma connection failed:', err));
+  client.$connect();
 
   return client;
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -5,22 +5,11 @@ import { PrismaClient } from '@prisma/client-and-server';
 import { PrismaMariaDb } from '@prisma/adapter-mariadb';
 
 const DATABASE_URL = process.env.DATABASE_URL;
-
 if (!DATABASE_URL) {
   throw new Error('DATABASE_URL environment variable is not set');
 }
 
-// Parse connection details
-const url = new URL(DATABASE_URL);
-const adapter = new PrismaMariaDb({
-  host: url.hostname,
-  port: parseInt(url.port || '3306'),
-  user: url.username,
-  password: url.password,
-  database: url.pathname.slice(1),
-  connectionLimit: 5,
-});
-
+const adapter = new PrismaMariaDb(DATABASE_URL);
 const prisma = new PrismaClient({ adapter });
 
 async function seed() {


### PR DESCRIPTION
I'm getting this error on staging:

```
pool timeout: failed to retrieve a connection from pool after 10001ms
```

Based on https://github.com/prisma/prisma/issues/28612 I'm trying to switch to using the raw database URL vs. parsing it.